### PR TITLE
refactor: input component improvements #P23-200

### DIFF
--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -2,11 +2,16 @@
 
 import { useState, useRef, useId } from "react";
 import styled, { css } from "styled-components";
+import { boolean } from "zod";
 
 import { Icon } from "../Icon";
 
 type StyledErrorProps = {
   hasError?: boolean;
+};
+
+type StyledInputProps = {
+  hasSupportingLabel?: boolean;
 };
 
 export type InputProps = {
@@ -86,6 +91,7 @@ export const Input = ({
         onChange={onChange}
         onFocus={onFocus}
         onBlur={onBlur}
+        hasSupportingLabel={Boolean(supportingLabel)}
       />
       <StyledLabel hasError={hasError} htmlFor={id || name}>
         {label}
@@ -104,7 +110,7 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-const StyledInput = styled.input<StyledErrorProps>`
+const StyledInput = styled.input<StyledErrorProps & StyledInputProps>`
   box-sizing: border-box;
   border: solid 2px #e1e1e1;
   border-radius: 8px;
@@ -114,6 +120,7 @@ const StyledInput = styled.input<StyledErrorProps>`
   caret-color: #515151;
   transition: border-color 200ms ease-out;
   width: 100%;
+  margin-bottom: ${({ hasSupportingLabel }) => (hasSupportingLabel ? "0" : "18px")};
 
   :focus {
     outline: none;

--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -41,8 +41,8 @@ export const Input = ({
     if (type === "password") {
       return (
         <StyledIcon
-          onClick={(e) => {
-            e.preventDefault();
+          onClick={(event) => {
+            event.preventDefault();
             setTypeOverride(typeOverride ? "" : "text");
             inputRef.current?.focus();
           }}>
@@ -64,7 +64,8 @@ export const Input = ({
     if (value && onInputCleared) {
       return (
         <StyledIcon
-          onClick={() => {
+          onClick={(event) => {
+            event.preventDefault();
             onInputCleared();
             inputRef.current?.focus();
           }}>

--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -43,8 +43,8 @@ export const Input = ({
         <StyledIcon
           onClick={(event) => {
             event.preventDefault();
-            setTypeOverride(typeOverride ? "" : "text");
             inputRef.current?.focus();
+            setTypeOverride(typeOverride ? "" : "text");
           }}>
           <Icon
             icon={typeOverride ? "visibility_off" : "visibility"}
@@ -66,8 +66,8 @@ export const Input = ({
         <StyledIcon
           onClick={(event) => {
             event.preventDefault();
-            onInputCleared();
             inputRef.current?.focus();
+            onInputCleared();
           }}>
           <Icon icon="cancel" color="#397B65" iconSize={20} />
         </StyledIcon>
@@ -169,6 +169,7 @@ const StyledLabel = styled.label<StyledErrorProps>`
   text-overflow: ellipsis;
   max-width: calc(100% - 32px);
   transition: all 200ms linear;
+  transition-delay: 0.25s;
   cursor: text;
 `;
 

--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -70,7 +70,7 @@ export const Input = ({
             inputRef.current?.focus();
             onInputCleared();
           }}>
-          <Icon icon="cancel" color="#397B65" iconSize={20} />
+          <Icon icon="cancel" color={theme.input.main} iconSize={20} />
         </StyledIcon>
       );
     }

--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useRef, useId } from "react";
+import { useState, useRef } from "react";
 import styled, { css } from "styled-components";
-import { boolean } from "zod";
 
 import { Icon } from "../Icon";
 
@@ -43,11 +42,10 @@ export const Input = ({
       return (
         <StyledIcon
           onClick={(e) => {
-            e.preventDefault()
+            e.preventDefault();
             setTypeOverride(typeOverride ? "" : "text");
             inputRef.current?.focus();
-          }}
-        >
+          }}>
           <Icon
             icon={typeOverride ? "visibility_off" : "visibility"}
             color={hasError ? "#b3261e" : "#397B65"}
@@ -69,14 +67,16 @@ export const Input = ({
           onClick={() => {
             onInputCleared();
             inputRef.current?.focus();
-          }}
-        >
+          }}>
           <Icon icon="cancel" color="#397B65" iconSize={20} />
         </StyledIcon>
       );
     }
     return null;
   };
+
+  const errorId =
+    hasError && supportingLabel ? `${id || name}-error-message` : undefined;
 
   return (
     <Wrapper>
@@ -92,13 +92,15 @@ export const Input = ({
         onFocus={onFocus}
         onBlur={onBlur}
         hasSupportingLabel={Boolean(supportingLabel)}
+        aria-invalid={hasError ? "true" : undefined}
+        aria-errormessage={errorId}
       />
       <StyledLabel hasError={hasError} htmlFor={id || name}>
         {label}
       </StyledLabel>
       {getButton()}
       {supportingLabel && (
-        <StyledSupportingLabel hasError={hasError}>
+        <StyledSupportingLabel hasError={hasError} id={errorId}>
           {supportingLabel}
         </StyledSupportingLabel>
       )}
@@ -120,7 +122,8 @@ const StyledInput = styled.input<StyledErrorProps & StyledInputProps>`
   caret-color: #515151;
   transition: border-color 200ms ease-out;
   width: 100%;
-  margin-bottom: ${({ hasSupportingLabel }) => (hasSupportingLabel ? "0" : "18px")};
+  margin-bottom: ${({ hasSupportingLabel }) =>
+    hasSupportingLabel ? "0" : "18px"};
 
   :focus {
     outline: none;
@@ -174,7 +177,7 @@ const StyledIcon = styled.button`
   top: 18px;
   border: none;
   background: none;
-  cursor: ${({ disabled }) => (disabled ? "text" : "pointer")};;
+  cursor: ${({ disabled }) => (disabled ? "text" : "pointer")};
   padding: 0;
   line-height: 0;
 `;


### PR DESCRIPTION
- improvements discussed on slack
   - accessibility of error messages, 
   - prevent form submitting on icon button click
   - reserve additional space for supporting label so that inputs does not shift when stacked in the form
- slight animation delay was added to eliminate label jumping when the user clicks on the icon button while the password input is empty ⬇️ 

https://user-images.githubusercontent.com/80450315/229596033-6d96daaf-4a6b-4c9e-9882-996c60971f54.mp4

