### PR TITLE
feat: sign up success-error screen #P23-210

### DIFF
--- a/apps/web/app/(regflow)/layout.styles.tsx
+++ b/apps/web/app/(regflow)/layout.styles.tsx
@@ -47,7 +47,6 @@ export const SectionStyled = styled.div`
     flex-grow: 1;
     padding: 0;
     margin-left: 32px;
-
   }
 
   ${device.desktop} {
@@ -61,7 +60,7 @@ export const SectionStyled = styled.div`
 
 export const TypoStyled = styled.div`
   max-width: 415px;
-`
+`;
 
 export const FormWrapperStyled = styled.div`
   overflow-x: auto;

--- a/apps/web/app/(regflow)/sign-up/SuccessErrorScreen.tsx
+++ b/apps/web/app/(regflow)/sign-up/SuccessErrorScreen.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useTranslate } from "lib/hooks";
+import styled from "styled-components";
+import { Icon, LinkComponent, ButtonStyled } from "ui";
+
+type SuccessType = {
+  success: boolean;
+};
+type SuccessErrorScreenProps = {
+  onBackToStart: () => void;
+  loginHref: string;
+} & SuccessType &
+  React.HTMLProps<HTMLDivElement>;
+
+const ScreenContent = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-direction: column;
+  min-height: 518px;
+
+  @media only screen and (min-width: 1024px) {
+    justify-content: center;
+  }
+`;
+
+const ScreenStatusWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ScreenCircle = styled.div<SuccessType>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: ${({ success, theme }) =>
+    success ? theme.signUp.main : theme.signUp.error};
+`;
+
+const IconStyled = styled(Icon)`
+  color: ${({ theme }) => theme.signUp.icon};
+  font-weight: 700;
+`;
+
+const ScreenHeader = styled.h2`
+  font-size: 1.5em;
+  line-height: 1.5em;
+  font-family: "Signika", sans-serif;
+  margin-top: 32px;
+  color: ${({ theme }) => theme.signUp.main};
+`;
+
+const ScreenSubheader = styled.p`
+  line-height: 1.5em;
+  font-family: "Inter", sans-serif;
+  margin-top: 4px;
+  color: ${({ theme }) => theme.signUp.text};
+`;
+
+const LinkStyled = styled(LinkComponent)`
+  margin-top: 136px;
+  text-decoration: none;
+  border: 2px solid ${({ theme }) => theme.button.primary.main};
+  color: ${({ theme }) => theme.signUp.link};
+  background-color: ${({ theme }) => theme.button.primary.main};
+
+  @media only screen and (min-width: 1024px) {
+    margin-top: 96px;
+  }
+`;
+
+export const SuccessErrorScreen = ({
+  success,
+  onBackToStart,
+  loginHref,
+}: SuccessErrorScreenProps) => {
+  const { dict, t } = useTranslate("SignUpPage");
+  const {
+    successErrorScreen: { status },
+  } = dict;
+
+  const statusHeaderText = success
+    ? t(status.success.header)
+    : t(status.error.header);
+  const statusSubheaderText = success
+    ? t(status.success.subheader)
+    : t(status.error.subheader);
+  const statusButtonText = success
+    ? t(status.success.button)
+    : t(status.error.button);
+
+  return (
+    <ScreenContent>
+      <ScreenStatusWrapper>
+        <ScreenCircle success={success}>
+          <IconStyled icon={success ? "done" : "priority_high"} iconSize={56} />
+        </ScreenCircle>
+        <ScreenHeader>{statusHeaderText}</ScreenHeader>
+        <ScreenSubheader>{statusSubheaderText}</ScreenSubheader>
+      </ScreenStatusWrapper>
+      {success ? (
+        <ButtonStyled as={LinkStyled} fullWidth href={loginHref}>
+          {statusButtonText}
+        </ButtonStyled>
+      ) : (
+        <ButtonStyled as={LinkStyled} fullWidth onClick={onBackToStart}>
+          {statusButtonText}
+        </ButtonStyled>
+      )}
+    </ScreenContent>
+  );
+};

--- a/apps/web/lib/dictionary.tsx
+++ b/apps/web/lib/dictionary.tsx
@@ -89,6 +89,38 @@ const dictionary = {
         pl: "Zaloguj się",
       },
     },
+    successErrorScreen: {
+      status: {
+        error: {
+          subheader: {
+            en: "The account with this email already exists",
+            pl: "Konto z tym adresem e-mail już istnieje",
+          },
+          header: {
+            en: "Something went wrong",
+            pl: "Coś poszło nie tak",
+          },
+          button: {
+            en: "Back to the registration process",
+            pl: "Powrót do rejestracji",
+          },
+        },
+        success: {
+          subheader: {
+            en: "You've successfully created your account",
+            pl: "Pomyślnie utworzyłeś swoje konto",
+          },
+          header: {
+            en: "Congratulations",
+            pl: "Gratulacje",
+          },
+          button: {
+            en: "Log in to your account",
+            pl: "Zaloguj się",
+          },
+        },
+      },
+    },
   },
   BudgetsPage: { title: { en: "Budgets page", pl: "Budżety" } },
   ReportsPage: { title: { en: "Reports page", pl: "Raporty" } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23156,7 +23156,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "material-symbols": "^0.5.1",
         "styled-components": "^5.3.8"
       },
       "devDependencies": {
@@ -38910,7 +38909,6 @@
         "@types/react": "^18.0.22",
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
-        "material-symbols": "^0.5.1",
         "react": "^18.2.0",
         "styled-components": "^5.3.8",
         "tsconfig": "*",

--- a/packages/ui/Button/index.tsx
+++ b/packages/ui/Button/index.tsx
@@ -2,26 +2,6 @@
 
 import styled, { css } from "styled-components";
 
-export const Button = ({
-  variant = "primary",
-  fullWidth = false,
-  disabled = false,
-  children,
-  onClick,
-  small = false,
-}: ButtonProps) => {
-  return (
-    <ButtonStyled
-      variant={variant}
-      onClick={onClick}
-      fullWidth={fullWidth}
-      disabled={disabled}
-      small={small}>
-      {children}
-    </ButtonStyled>
-  );
-};
-
 type ButtonProps = {
   variant?: "primary" | "secondary" | "simple";
   fullWidth?: boolean;
@@ -30,7 +10,7 @@ type ButtonProps = {
   small?: boolean;
 } & React.HTMLProps<HTMLButtonElement>;
 
-const ButtonStyled = styled.button<ButtonProps>`
+export const ButtonStyled = styled.button<ButtonProps>`
   box-sizing: border-box;
   display: inline-flex;
   justify-content: center;
@@ -113,3 +93,25 @@ const ButtonStyled = styled.button<ButtonProps>`
       width: 100%;
     `}
 `;
+
+export const Button = ({
+  variant = "primary",
+  fullWidth = false,
+  disabled = false,
+  children,
+  onClick,
+  small = false,
+  className,
+}: ButtonProps) => {
+  return (
+    <ButtonStyled
+      className={className}
+      variant={variant}
+      onClick={onClick}
+      fullWidth={fullWidth}
+      disabled={disabled}
+      small={small}>
+      {children}
+    </ButtonStyled>
+  );
+};

--- a/packages/ui/Icon/index.tsx
+++ b/packages/ui/Icon/index.tsx
@@ -50,7 +50,9 @@ export type IconType =
   | "savings"
   | "directions_car"
   | "payments"
-  | "subscriptions";
+  | "subscriptions"
+  | "done"
+  | "priority_high";
 
 type styledIconProps = {
   color?: string;
@@ -84,11 +86,17 @@ export const StyledIcon = styled.span<styledIconProps>`
     `}
 `;
 
-export const Icon = ({ icon, filled = false, color, iconSize }: IconProps) => {
+export const Icon = ({
+  icon,
+  filled = false,
+  color,
+  iconSize,
+  className,
+}: IconProps) => {
   return (
     <StyledIcon
       color={color}
-      className="material-symbols-rounded"
+      className={`material-symbols-rounded ${className || ""}`}
       iconSize={iconSize}
       filled={filled}>
       {icon}

--- a/packages/ui/Link/index.tsx
+++ b/packages/ui/Link/index.tsx
@@ -1,32 +1,17 @@
 "use client";
+
 import styled from "styled-components";
+import Link from "next/link";
 
 type LinkComponentProps = {
   href?: any;
   children?: string;
 } & React.HTMLProps<HTMLElement>;
 
-export const LinkComponent = ({
-  href,
-  children,
-  onClick,
-}: LinkComponentProps) => {
-  return onClick ? (
-    <LinkComponentButtonStyled onClick={onClick}>
-      {children}
-    </LinkComponentButtonStyled>
-  ) : (
-    <LinkComponentAnchorStyled href={href}>
-      {children}
-    </LinkComponentAnchorStyled>
-  );
-};
-
-export const LinkComponentAnchorStyled = styled.a<LinkComponentProps>`
+export const LinkComponentAnchorStyled = styled(Link)<LinkComponentProps>`
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
-  font-size: 16px;
   color: ${({ theme }) => theme.link.main};
 `;
 
@@ -34,9 +19,25 @@ export const LinkComponentButtonStyled = styled.button<LinkComponentProps>`
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
-  font-size: 16px;
   color: ${({ theme }) => theme.link.main};
   cursor: pointer;
   border: none;
   background-color: transparent;
 `;
+
+export const LinkComponent = ({
+  href,
+  children,
+  onClick,
+  className,
+}: LinkComponentProps) => {
+  return onClick ? (
+    <LinkComponentButtonStyled className={className} onClick={onClick}>
+      {children}
+    </LinkComponentButtonStyled>
+  ) : (
+    <LinkComponentAnchorStyled className={className} href={href}>
+      {children}
+    </LinkComponentAnchorStyled>
+  );
+};

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -1,6 +1,6 @@
-export {NavItem} from "./NavItem";
-export {NavList} from "./NavList"
-export { Button } from "./Button";
+export { NavItem } from "./NavItem";
+export { NavList } from "./NavList";
+export { Button, ButtonStyled } from "./Button";
 export { SideNavigationBar } from "./SideNavigationBar";
 export { Card } from "./Card";
 export { ButtonGroup } from "./ButtonGroup";

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -159,6 +159,13 @@ export const theme = {
     hover: colors.Teal1,
     outline: colors.Teal5,
   },
+  signUp: {
+    main: colors.Teal10,
+    text: colors.Neutral8,
+    error: colors.Supporting4,
+    icon: colors.BasicWhite,
+    link: colors.BasicWhite,
+  },
 };
 
 export type ThemeType = typeof theme;


### PR DESCRIPTION
- Ticket: https://tracker.intive.com/jira/browse/PATRO23-210
- [Success Preview](https://patronage2023-js-web-git-feature-p23-210-step-f918d5-wlechowicz.vercel.app/sign-up)
- [Error Preview](https://patronage2023-js-web-git-feature-p23-210-step-f918d5-wlechowicz.vercel.app/sign-up/error)

Task: Prepare (4/4) screen for ```FlowController```.

```SuccessErrorScreen``` receives three types of props:
- ```success```: status of validation (```boolean```)
- ```onBackToStart```: function that takes the user back to the first screen in the registration process
- ```loginHref```: if the ```success``` status is true, the button on the screen will become a link with a href property equal to  ```loginHref```

in code:
```javascript 
<SuccessErrorScreen success={false} onBackToStart={onBackToStart} loginHref="/home" />
```

Changes:
- ```dictionary.tsx```: Added translations for SuccessErrorScreen elements
- ```theme.tsx```: Added colors to the theme object
- ```Icon/index.tsx```: Two new icons added

Fixes: 
- ```<LinkComponent>```: 
  - ```a``` was changed for Next ```Link```
  - can now be styled using styled components
- ```<Icon>```: 
  - can now be styled using styled components
 - ```<Button>```: 
   - can now be styled using styled components
 
To do:
- ~~wait for ```ref: improve rwd of registration layout #P23-198```  PR~~
- Adjust styles in the ```Card```


