### PR TITLE
feat: sign up - step1 - email screen #P23-207

### DIFF
--- a/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
+++ b/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
@@ -1,36 +1,62 @@
 "use client";
 
 import { Field, Form } from "houseform";
-import { Button, Input } from "ui";
+import { Button, Input, LinkComponent } from "ui";
 import styled from "styled-components";
 import { z } from "zod";
 import { useTranslate } from "lib/hooks";
-import { error } from "console";
 
-export function EmailScreen() {
-  const { t, dict } = useTranslate("SignInPage");
-  const { form } = dict;
+type EmailScreenProps = {
+  onNext: (password: string) => void;
+};
+
+const StyledForm = styled.form`
+  display: flex;
+  margin: 0 auto;
+  gap: 24px;
+  width: 312px;
+  height: 542px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  @media (min-width: 767px) {
+    width: 416px;
+  }
+`;
+
+const FooterStyled = styled.div`
+  font-size: 16px;
+  line-height: 150%;
+  font-weight: 400;
+  margin-top: 42px;
+`;
+
+export const EmailScreen = ({ onNext }: EmailScreenProps) => {
+  const { t, dict } = useTranslate("SignUpPage");
+  const { emailScreen } = dict;
 
   return (
-    <Form onSubmit={() => {}}>
-      {({ submit, errors }) => (
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            submit();
+    <Form
+      onSubmit={(values) => {
+        onNext(values.email);
+      }}>
+      {({ submit }) => (
+        <StyledForm
+          onSubmit={(event) => {
+            event.preventDefault();
           }}>
           <Field
             name="email"
             initialValue={""}
-            onSubmitValidate={z
+            onChangeValidate={z
               .string()
-              .email(t(form.emailInput.wrongFormatError))}
-          >
+              .email(t(emailScreen.invalidEmailError))}>
             {({ value, setValue, errors }) => (
               <Input
                 name="email"
                 type="email"
-                label="Email"
+                label={t(emailScreen.inputLabel)}
                 value={value}
                 onChange={(event) => setValue(event.currentTarget.value)}
                 onInputCleared={() => setValue("")}
@@ -40,10 +66,16 @@ export function EmailScreen() {
             )}
           </Field>
           <Button onClick={submit} type="submit" fullWidth>
-            Continue
+            {t(emailScreen.buttonNext)}
           </Button>
-        </form>
+          <FooterStyled>
+            {t(emailScreen.footer)}{" "}
+            <LinkComponent href="/sign-in">
+              {t(emailScreen.footerLink)}
+            </LinkComponent>
+          </FooterStyled>
+        </StyledForm>
       )}
     </Form>
   );
-}
+};

--- a/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
+++ b/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Field, Form } from "houseform";
+import { Button, Input } from "ui";
+import styled from "styled-components";
+import { z } from "zod";
+import { useTranslate } from "lib/hooks";
+import { error } from "console";
+
+export function EmailScreen() {
+  const { t, dict } = useTranslate("SignInPage");
+  const { form } = dict;
+
+  return (
+    <Form onSubmit={() => {}}>
+      {({ submit, errors }) => (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}>
+          <Field
+            name="email"
+            initialValue={""}
+            onSubmitValidate={z
+              .string()
+              .email(t(form.emailInput.wrongFormatError))}
+          >
+            {({ value, setValue, errors }) => (
+              <Input
+                name="email"
+                type="email"
+                label="Email"
+                value={value}
+                onChange={(event) => setValue(event.currentTarget.value)}
+                onInputCleared={() => setValue("")}
+                hasError={errors.length > 0}
+                supportingLabel={errors.length ? errors : undefined}
+              />
+            )}
+          </Field>
+          <Button onClick={submit} type="submit" fullWidth>
+            Continue
+          </Button>
+        </form>
+      )}
+    </Form>
+  );
+}

--- a/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
+++ b/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
@@ -7,7 +7,8 @@ import { z } from "zod";
 import { useTranslate } from "lib/hooks";
 
 type EmailScreenProps = {
-  onNext: (password: string) => void;
+  onNext: (email: string) => void;
+  email?: string;
 };
 
 const StyledForm = styled.form`
@@ -32,7 +33,7 @@ const FooterStyled = styled.div`
   margin-top: 42px;
 `;
 
-export const EmailScreen = ({ onNext }: EmailScreenProps) => {
+export const EmailScreen = ({ onNext, email = "" }: EmailScreenProps) => {
   const { t, dict } = useTranslate("SignUpPage");
   const { emailScreen } = dict;
 
@@ -48,7 +49,7 @@ export const EmailScreen = ({ onNext }: EmailScreenProps) => {
           }}>
           <Field
             name="email"
-            initialValue={""}
+            initialValue={email}
             onChangeValidate={z
               .string()
               .email(t(emailScreen.invalidEmailError))}>

--- a/apps/web/app/(regflow)/sign-up/page.tsx
+++ b/apps/web/app/(regflow)/sign-up/page.tsx
@@ -1,5 +1,10 @@
-import { SignUpForm } from "./SignUpForm";
+// import { SignUpForm } from "./SignUpForm";
+"use client"
+import { EmailScreen } from "./EmailScreen"
 
 export default function SignUpPage() {
-  return <SignUpForm />;
+  // return <SignUpForm />;
+  return (
+    <EmailScreen onNext={ () => console.log('test')} />
+  );
 }

--- a/apps/web/app/(regflow)/sign-up/page.tsx
+++ b/apps/web/app/(regflow)/sign-up/page.tsx
@@ -1,10 +1,5 @@
-// import { SignUpForm } from "./SignUpForm";
-"use client"
-import { EmailScreen } from "./EmailScreen"
+import { SignUpForm } from "./SignUpForm";
 
 export default function SignUpPage() {
-  // return <SignUpForm />;
-  return (
-    <EmailScreen onNext={ () => console.log('test')} />
-  );
+  return <SignUpForm />;
 }

--- a/apps/web/lib/dictionary.tsx
+++ b/apps/web/lib/dictionary.tsx
@@ -67,6 +67,28 @@ const dictionary = {
       en: "Hello from Sign-Up page",
       pl: "Witaj ze strony rejestracji",
     },
+    emailScreen: {
+      inputLabel: {
+        en: "Email",
+        pl: "Email",
+      },
+      invalidEmailError: {
+        en: "This is not a valid email",
+        pl: "To nie jest prawidłowy adres email",
+      },
+      buttonNext: {
+        en: "Continue",
+        pl: "Dalej",
+      },
+      footer: {
+        en: "Already have an account?",
+        pl: "Posiadasz już konto?",
+      },
+      footerLink: {
+        en: "Log in",
+        pl: "Zaloguj się",
+      },
+    },
   },
   BudgetsPage: { title: { en: "Budgets page", pl: "Budżety" } },
   ReportsPage: { title: { en: "Reports page", pl: "Raporty" } },


### PR DESCRIPTION
# step 1 of a sign-up process - email screen
- task: https://tracker.intive.com/jira/browse/PATRO23-207
- preview: https://patronage2023-js-web-git-feature-p23-207-sign-61dbe2-wlechowicz.vercel.app/sign-up

To discuss - position of text element with link ( `<FooterStyled>`) - right now it is positioned in the same distance from the button as on the design. Implementation has less elements than design, so this text looks kinda strange in this position ;-) maybe it should be closer to the button or more at the bottom of the card?

<img width="350" alt="image" src="https://user-images.githubusercontent.com/80450315/231399736-9be5e376-97a4-4969-9b13-f2e11a3c6309.png">
