### PR TITLE
refactor: add link to logo #P23-251

### DIFF
--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -58,7 +58,7 @@ const LogoSignet = styled.span<LogoSignetProps>`
 
 export const Logo = ({ white, logoWidth = 144 }: LogoProps) => {
   return (
-    <LogoStyledContainer logoWidth={logoWidth} white={white} href={"/"}>
+    <LogoStyledContainer logoWidth={logoWidth} white={white} href="/">
       <LogoSignet logoWidth={logoWidth} white={white} />
       <span>Inbudget</span>
     </LogoStyledContainer>

--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -2,25 +2,25 @@
 
 import styled, { css } from "styled-components";
 
-export const logoVersions = {
+const logoVersions = {
   colorURL:
     "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAyOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTAgMTEuNTgwNkMwIDEwLjI2ODQgMC44NTI3NDkgOS4xMDg1MiAyLjEwNTE4IDguNzE3MTNMMjQuMTA1MiAxLjg0MjEzQzI2LjAzNyAxLjIzODQ1IDI4IDIuNjgxNjUgMjggNC43MDU1N1YxOS40MTk0QzI4IDIwLjczMTYgMjcuMTQ3MyAyMS44OTE1IDI1Ljg5NDggMjIuMjgyOUwzLjg5NDgzIDI5LjE1NzlDMS45NjMwNCAyOS43NjE2IDAgMjguMzE4MyAwIDI2LjI5NDRWMTEuNTgwNloiIGZpbGw9IiM1M0E3ODUiLz4KPHBhdGggb3BhY2l0eT0iMC42IiBkPSJNMCAxMS43MDU2QzAgOS42ODE2NSAxLjk2MzAzIDguMjM4NDUgMy44OTQ4MiA4Ljg0MjEzTDI1Ljg5NDggMTUuNzE3MUMyNy4xNDczIDE2LjEwODUgMjggMTcuMjY4NCAyOCAxOC41ODA2VjMzLjI5NDRDMjggMzUuMzE4MyAyNi4wMzcgMzYuNzYxNiAyNC4xMDUyIDM2LjE1NzlMMi4xMDUxOCAyOS4yODI5QzAuODUyNzQ5IDI4Ljg5MTUgMCAyNy43MzE2IDAgMjYuNDE5NFYxMS43MDU2WiIgZmlsbD0iIzgyRDNBRiIvPgo8L3N2Zz4K",
   whiteURL:
     "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAyOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTAgMTEuNTgwNkMwIDEwLjI2ODQgMC44NTI3NDkgOS4xMDg1MiAyLjEwNTE4IDguNzE3MTNMMjQuMTA1MiAxLjg0MjEzQzI2LjAzNyAxLjIzODQ1IDI4IDIuNjgxNjUgMjggNC43MDU1N1YxOS40MTk0QzI4IDIwLjczMTYgMjcuMTQ3MyAyMS44OTE1IDI1Ljg5NDggMjIuMjgyOUwzLjg5NDgzIDI5LjE1NzlDMS45NjMwNCAyOS43NjE2IDAgMjguMzE4MyAwIDI2LjI5NDRWMTEuNTgwNloiIGZpbGw9IiNGQ0ZDRkMiLz4KPHBhdGggb3BhY2l0eT0iMC42IiBkPSJNMCAxMS43MDU2QzAgOS42ODE2NSAxLjk2MzAzIDguMjM4NDUgMy44OTQ4MiA4Ljg0MjEzTDI1Ljg5NDggMTUuNzE3MUMyNy4xNDczIDE2LjEwODUgMjggMTcuMjY4NCAyOCAxOC41ODA2VjMzLjI5NDRDMjggMzUuMzE4MyAyNi4wMzcgMzYuNzYxNiAyNC4xMDUyIDM2LjE1NzlMMi4xMDUxOCAyOS4yODI5QzAuODUyNzQ5IDI4Ljg5MTUgMCAyNy43MzE2IDAgMjYuNDE5NFYxMS43MDU2WiIgZmlsbD0iI0QyRTFEQiIvPgo8L3N2Zz4K",
 };
 
-export type LogoProps = {
+type LogoProps = {
   white?: boolean;
   logoWidth?: number;
 };
 
-export type LogoSignetProps = Pick<LogoProps, "logoWidth" | "white">;
+type LogoSignetProps = Pick<LogoProps, "logoWidth" | "white">;
 
-export type ContainerProps = {
+type ContainerProps = {
   children?: React.ReactNode;
 } & Pick<LogoProps, "logoWidth" | "white">;
 
-export const LogoStyledContainer = styled.div<ContainerProps>`
+const LogoStyledContainer = styled.div<ContainerProps>`
   @import url("https://fonts.googleapis.com/css2?family=Signika:wght@600&display=swap");
   font-family: "Signika", sans-serif;
   font-weight: 600;
@@ -42,9 +42,9 @@ export const LogoStyledContainer = styled.div<ContainerProps>`
       letter-spacing: ${((logoWidth / 6) * -0.02).toFixed(2) + "px"};
     `}
 `;
-export const LogoSignet = styled.div<LogoSignetProps>`
-  background: url(${({ white }) =>
-      white ? logoVersions.whiteURL : logoVersions.colorURL})
+
+const LogoSignet = styled.div<LogoSignetProps>`
+  background: url(${({ white }) => white ? logoVersions.whiteURL : logoVersions.colorURL})
     no-repeat center / contain;
   height: 100%;
   ${({ logoWidth }) =>
@@ -53,6 +53,7 @@ export const LogoSignet = styled.div<LogoSignetProps>`
       width: ${(logoWidth * 0.25).toFixed(2) + "px"};
     `}
 `;
+
 export const Logo = ({ white, logoWidth = 144 }: LogoProps) => {
   return (
     <LogoStyledContainer logoWidth={logoWidth} white={white}>

--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -20,10 +20,11 @@ type ContainerProps = {
   children?: React.ReactNode;
 } & Pick<LogoProps, "logoWidth" | "white">;
 
-const LogoStyledContainer = styled.div<ContainerProps>`
+const LogoStyledContainer = styled.a<ContainerProps>`
   @import url("https://fonts.googleapis.com/css2?family=Signika:wght@600&display=swap");
   font-family: "Signika", sans-serif;
   font-weight: 600;
+  text-decoration: none;
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -56,7 +57,7 @@ const LogoSignet = styled.div<LogoSignetProps>`
 
 export const Logo = ({ white, logoWidth = 144 }: LogoProps) => {
   return (
-    <LogoStyledContainer logoWidth={logoWidth} white={white}>
+    <LogoStyledContainer logoWidth={logoWidth} white={white} href={"/"}>
       <LogoSignet logoWidth={logoWidth} white={white} />
       <span>Inbudget</span>
     </LogoStyledContainer>

--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -44,7 +44,7 @@ const LogoStyledContainer = styled.a<ContainerProps>`
     `}
 `;
 
-const LogoSignet = styled.div<LogoSignetProps>`
+const LogoSignet = styled.span<LogoSignetProps>`
   background: url(${({ white }) => white ? logoVersions.whiteURL : logoVersions.colorURL})
     no-repeat center / contain;
   height: 100%;

--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import styled, { css } from "styled-components";
 
 const logoVersions = {
@@ -20,7 +21,7 @@ type ContainerProps = {
   children?: React.ReactNode;
 } & Pick<LogoProps, "logoWidth" | "white">;
 
-const LogoStyledContainer = styled.a<ContainerProps>`
+const LogoStyledContainer = styled(Link)<ContainerProps>`
   @import url("https://fonts.googleapis.com/css2?family=Signika:wght@600&display=swap");
   font-family: "Signika", sans-serif;
   font-weight: 600;

--- a/packages/ui/Logo/index.tsx
+++ b/packages/ui/Logo/index.tsx
@@ -45,7 +45,8 @@ const LogoStyledContainer = styled.a<ContainerProps>`
 `;
 
 const LogoSignet = styled.span<LogoSignetProps>`
-  background: url(${({ white }) => white ? logoVersions.whiteURL : logoVersions.colorURL})
+  background: url(${({ white }) =>
+      white ? logoVersions.whiteURL : logoVersions.colorURL})
     no-repeat center / contain;
   height: 100%;
   ${({ logoWidth }) =>


### PR DESCRIPTION
# Add link to the logo

Task: https://tracker.intive.com/jira/browse/PATRO23-251

- wrapper was changed from `div` to `a` and a `href` was added
- child element was changed to be an inline element like the parent ( from `div` to `span`)
- additionally, unnecessary exports were removed