### PR TITLE
feat: budget icon component #P23-245

### DIFF
--- a/apps/storybook/stories/BudgetIcon.stories.tsx
+++ b/apps/storybook/stories/BudgetIcon.stories.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import styled from "styled-components";
+
+import { BudgetIcon } from "ui";
+
+export default {
+  title: "BudgetIcon",
+  component: BudgetIcon,
+} as ComponentMeta<typeof BudgetIcon>;
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  min-height: 80px;
+`;
+
+const BudgetIconWrapper = styled.div`
+  display: flex;
+  min-width: 80px;
+`;
+
+const Title = styled.span`
+  font-size: 24px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.budgetIcon.main};
+`;
+
+const Description = styled.span`
+  font-size: 12px;
+  color: "#626262";
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-grow: 1;
+`;
+const TitleDescriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-start;
+  gap: 20px;
+`;
+
+const BudgetIconComponent: ComponentStory<typeof BudgetIcon> = ({
+  ...args
+}) => {
+  return (
+    <Wrapper>
+      <BudgetIconWrapper>
+        <BudgetIcon {...args} />
+      </BudgetIconWrapper>
+      <Info>
+        <TitleDescriptionWrapper>
+          <Title>Bills</Title>
+          <Description>This is a description of Bills budget.</Description>
+        </TitleDescriptionWrapper>
+      </Info>
+    </Wrapper>
+  );
+};
+
+export const BudgetIconWithBudgetNameAndDescription = BudgetIconComponent.bind(
+  {}
+);
+BudgetIconWithBudgetNameAndDescription.args = {
+  icon: "wallet",
+};

--- a/packages/ui/BudgetIcon/index.tsx
+++ b/packages/ui/BudgetIcon/index.tsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import { ReactNode } from "react";
+import { Icon, IconType } from "../Icon";
+
+type BudgetIconProps = {
+  icon?: IconType;
+  children: ReactNode;
+};
+
+const BudgetIconStyled = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  height: 100%;
+  width: 100%;
+  background-color: ${({ theme }) => theme.budgetIcon.background};
+  color: ${({ theme }) => theme.budgetIcon.main};
+`;
+
+export const BudgetIcon = ({ icon, children }: BudgetIconProps) => {
+  return (
+    <BudgetIconStyled>
+      {icon ? (
+        <>
+          <Icon icon={icon} iconSize={40} />
+          {children}
+        </>
+      ) : (
+        <>{children}</>
+      )}
+    </BudgetIconStyled>
+  );
+};

--- a/packages/ui/IconPicker/iconPicker.styled.tsx
+++ b/packages/ui/IconPicker/iconPicker.styled.tsx
@@ -10,20 +10,6 @@ export const IconPickerStyled = styled.div`
   z-index: 1;
 `;
 
-export const IconAndButtonWrapperStyled = styled.div`
-  position: absolute;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 112px;
-  width: 112px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.iconPicker.background};
-  color: ${({ theme }) => theme.iconPicker.main};
-`;
-
 export const EditButtonStyled = styled.button`
   position: absolute;
   left: 84px;

--- a/packages/ui/IconPicker/index.tsx
+++ b/packages/ui/IconPicker/index.tsx
@@ -2,11 +2,11 @@
 import { ReactNode, useEffect, useState } from "react";
 import {
   IconPickerStyled,
-  IconAndButtonWrapperStyled,
   IconsSelectorStyled,
   EditButtonStyled,
   SelectIconButtonStyled,
 } from "./iconPicker.styled";
+import { BudgetIcon } from "../BudgetIcon";
 import { Icon, IconType } from "../Icon";
 
 type IconPickerProps = {
@@ -90,16 +90,11 @@ export const IconPicker = ({
 
   return (
     <IconPickerStyled>
-      <IconAndButtonWrapperStyled>
-        {currentIcon ? (
-          <Icon icon={currentIcon} iconSize={40} />
-        ) : (
-          <>{children}</>
-        )}
+      <BudgetIcon icon={currentIcon}>
         <EditButtonStyled onClick={handleEditButtonClick}>
           <Icon icon="edit" iconSize={12} />
         </EditButtonStyled>
-      </IconAndButtonWrapperStyled>
+      </BudgetIcon>
       {iconSelectorVisible && (
         <IconSelector
           icons={icons}

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -19,3 +19,4 @@ export { Checkbox } from "./Checkbox";
 export { Textarea } from "./Textarea";
 export { IconPicker } from "./IconPicker";
 export { Modal } from "./Modal";
+export { BudgetIcon } from "./BudgetIcon";

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -190,6 +190,10 @@ export const theme = {
     link: colors.BasicWhite,
     accent: colors.Neutral2,
   },
+  budgetIcon: {
+    main: colors.Teal10,
+    background: colors.Neutral1,
+  },
 };
 
 export type ThemeType = typeof theme;


### PR DESCRIPTION
Budget Icon component: https://tracker.intive.com/jira/browse/PATRO23-245.

- Component receives `icon` prop that determines which icon is displayed
- Component size depends on the size of a parent (`width: 100%; height: 100%`)
- Component is also used in `IconPicker` component

There's an example of component usage in storybook that you can take a look at. It's draft, so there may be some differences compared with Figma design.

**Most important question: is it enough to set width/height to 100% as to achieve dependency on parent element?**