### PR TITLE
fix: currency selector styles in storybook #P23-267 

### DIFF
--- a/apps/storybook/stories/CurrencySelector.stories.tsx
+++ b/apps/storybook/stories/CurrencySelector.stories.tsx
@@ -8,14 +8,14 @@ export default {
 } as ComponentMeta<typeof CurrencySelect>;
 
 const CurrencySelectTemplate: ComponentStory<typeof CurrencySelect> = ({...args }) => (
-    <StyledDiv><CurrencySelect {...args}/></StyledDiv>
+    <Wrapper><CurrencySelect {...args}/></Wrapper>
 );
 
 export const Select = CurrencySelectTemplate.bind({});
 Select.args = {
-    label: "Currency"
+    label: "Currency",
 };
 
-const StyledDiv = styled.div`
+const Wrapper = styled.div`
   width: 206px;  
 `;

--- a/apps/storybook/stories/CurrencySelector.stories.tsx
+++ b/apps/storybook/stories/CurrencySelector.stories.tsx
@@ -14,8 +14,3 @@ export const Select = CurrencySelectTemplate.bind({});
 Select.args = {
 };
 
-export const SelectWithError = CurrencySelectTemplate.bind({});
-SelectWithError.args = {
-    hasError: true,
-    hasSupportingLabel: true,
-}

--- a/apps/storybook/stories/CurrencySelector.stories.tsx
+++ b/apps/storybook/stories/CurrencySelector.stories.tsx
@@ -18,5 +18,5 @@ Select.args = {
 };
 
 const Wrapper = styled.div`
-  width: 206px;  
+  width: 210px;  
 `;

--- a/apps/storybook/stories/CurrencySelector.stories.tsx
+++ b/apps/storybook/stories/CurrencySelector.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { CurrencySelect } from "ui";
+import styled from "styled-components";
 
 export default {
     title: "Currency Select",
@@ -7,10 +8,14 @@ export default {
 } as ComponentMeta<typeof CurrencySelect>;
 
 const CurrencySelectTemplate: ComponentStory<typeof CurrencySelect> = ({...args }) => (
-    <CurrencySelect />
+    <StyledDiv><CurrencySelect {...args}/></StyledDiv>
 );
 
 export const Select = CurrencySelectTemplate.bind({});
 Select.args = {
+    label: "Currency"
 };
 
+const StyledDiv = styled.div`
+  width: 206px;  
+`;

--- a/apps/storybook/stories/CurrencySelector.stories.tsx
+++ b/apps/storybook/stories/CurrencySelector.stories.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { CurrencySelect } from "ui";
 import styled from "styled-components";

--- a/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
+++ b/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
@@ -23,21 +23,21 @@ export const SelectTrigger = styled(Select.Trigger)<SelectTriggerProps>`
   padding-right: 10px;
   transition: border-color 200ms ease-out;
 
-  & label {
-    position: absolute;
-    transform: translateY(-24px);
-    font-size: 12px;
-    font-weight: 600;
-    background-color: ${({ theme }) => theme.input.labelBackground};
-    padding-left: 4px;
-    padding-right: 4px;
-  }
-
   :focus {
     transition: border-color 200ms ease-out;
     outline: none;
     border-color: ${({ theme }) => theme.input.focus};
   }
+`;
+
+export const StyledLabel = styled.label`
+    position: absolute;
+    margin-top: -24px;
+    font-size: 12px;
+    font-weight: 600;
+    background-color: ${({ theme }) => theme.input.labelBackground};
+    padding-left: 4px;
+    padding-right: 4px;
 `;
 
 export const SelectIcon = styled(Select.Icon)`

--- a/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
+++ b/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
@@ -59,18 +59,21 @@ export const SelectContent = styled(Select.Content)`
 `;
 
 export const SelectItem = styled(Select.Item)`
+  outline-color: ${({ theme }) => theme.input.focus};
   padding: 16px;
   gap: 8px;
-
+  
   &:focus {
     color: ${({ theme }) => theme.input.main};
     background-color: ${({ theme }) => theme.currencySelect.focusBackground};
-    outline-color: transparent;
     &:first-child {
       border-radius: 1em 1em 0 0;
     }
     &:last-child {
       border-radius: 0 0 1em 1em;
+    }
+    &:hover{
+      outline: transparent;
     }
   }
 `;

--- a/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
+++ b/packages/ui/CurrencySelect/CurrencySelect.styled.tsx
@@ -59,13 +59,13 @@ export const SelectContent = styled(Select.Content)`
 `;
 
 export const SelectItem = styled(Select.Item)`
-  outline-color: ${({ theme }) => theme.input.focus};
   padding: 16px;
   gap: 8px;
 
   &:focus {
     color: ${({ theme }) => theme.input.main};
     background-color: ${({ theme }) => theme.currencySelect.focusBackground};
+    outline-color: transparent;
     &:first-child {
       border-radius: 1em 1em 0 0;
     }

--- a/packages/ui/CurrencySelect/index.tsx
+++ b/packages/ui/CurrencySelect/index.tsx
@@ -65,7 +65,7 @@ export const CurrencySelect = ({
       }}>
       <SelectTrigger id={id}>
         <StyledLabel htmlFor="currency">{label}</StyledLabel>
-        <Select.Value></Select.Value>
+        <Select.Value placeholder="USD"></Select.Value>
         <SelectIcon>
           <Icon
             icon={isOpen ? "arrow_drop_up" : "arrow_drop_down"}

--- a/packages/ui/CurrencySelect/index.tsx
+++ b/packages/ui/CurrencySelect/index.tsx
@@ -10,6 +10,7 @@ import {
   SelectPortal,
   SelectRoot,
   SelectTrigger,
+  StyledLabel,
   StyledCurrencyLabel,
   StyledTag,
 } from "./CurrencySelect.styled";
@@ -63,7 +64,7 @@ export const CurrencySelect = ({
         setIsOpen(!isOpen);
       }}>
       <SelectTrigger id={id}>
-        <label htmlFor="currency">{label}</label>
+        <StyledLabel htmlFor="currency">{label}</StyledLabel>
         <Select.Value></Select.Value>
         <SelectIcon>
           <Icon


### PR DESCRIPTION
Hello! This is PR of my task [Fix Currency Selector styles in storybook](https://tracker.intive.com/jira/browse/PATRO23-267).
I think now it looks like in web and looks more like in design (I deleted borders on focus). 

[Check WEB](https://patronage2023-js-dbqlopdja-wlechowicz.vercel.app/)
Budgets > Add new budget > Currency

[Check Storybook](https://patronage2023-js-storybook-jyppd9mtk-wlechowicz.vercel.app/?path=/story/currency-select--select)

Have a nice day! 😃 