### PR TITLE
discovery: pagination behaviour #P23-272

### DIFF
--- a/apps/web/app/(navigation)/(singleCard)/MainPageTranslated.tsx
+++ b/apps/web/app/(navigation)/(singleCard)/MainPageTranslated.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { TypoStyled, LinkStyled } from "app/(navigation)/HomePageComponents";
-import { useTranslate } from "lib/hooks";
 import styled from "styled-components";
+import { Pagination } from "app/(navigation)/Pagination";
+
+//simulation of transaction's data
+const items: number[] = [];
+for (let i = 1; i <= 100; i++) {
+  items.push(i);
+}
 
 export const MainPageTranslated = () => {
-  const { dict, t } = useTranslate("MainPage");
-
   const ContentWrapperStyled = styled.div`
     display: flex;
     flex-direction: column;
@@ -15,8 +18,7 @@ export const MainPageTranslated = () => {
 
   return (
     <ContentWrapperStyled>
-      <TypoStyled>{t(dict.welcomeText)}</TypoStyled>
-      <LinkStyled href="/sign-up">{t(dict.createAccountLink)}</LinkStyled>
+      <Pagination data={items} itemsPerPage={10} />
     </ContentWrapperStyled>
   );
 };

--- a/apps/web/app/(navigation)/Pagination.tsx
+++ b/apps/web/app/(navigation)/Pagination.tsx
@@ -78,6 +78,7 @@ export function Pagination({ data, itemsPerPage }: PaginationProps) {
         nextClassName="next"
         previousLinkClassName="previous-link"
         nextLinkClassName="next-link"
+        disabledClassName="disabled"
         pageClassName="page"
         activeClassName="page-active"
         breakClassName="break"

--- a/apps/web/app/(navigation)/Pagination.tsx
+++ b/apps/web/app/(navigation)/Pagination.tsx
@@ -57,7 +57,7 @@ export function Pagination({ data, itemsPerPage }: PaginationProps) {
       <Wrapper>
         {currentItems?.map((item) => {
           return (
-            <TransactionWrapper>Transaction {item}</TransactionWrapper>
+            <TransactionWrapper key={item}>Transaction {item}</TransactionWrapper>
           );
         })}
       </Wrapper>
@@ -70,7 +70,7 @@ export function Pagination({ data, itemsPerPage }: PaginationProps) {
           <IconStyled icon="chevron_left" color="#ccc" iconSize={15} />
         }
         onPageChange={handlePageClick}
-        pageRangeDisplayed={3}
+        pageRangeDisplayed={5}
         pageCount={pageCount}
         renderOnZeroPageCount={null}
         containerClassName="container"

--- a/apps/web/app/(navigation)/Pagination.tsx
+++ b/apps/web/app/(navigation)/Pagination.tsx
@@ -1,0 +1,87 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import ReactPaginate from "react-paginate";
+import "../css/pagination.css";
+import { Icon } from "ui";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  width: 400px;
+  padding: 20px;
+  box-shadow: 0 2px 6px rgba(32, 41, 50, 0.1);
+  overflow: hidden;
+`;
+
+const TransactionWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  padding: 5px;
+  border-bottom: 1px solid #ccc;
+  margin: 5px;
+  font-size: 12px;
+`;
+
+const IconStyled = styled(Icon)`
+  font-weight: normal;
+`;
+
+type PaginationProps = { data: Array<number>; itemsPerPage: number };
+
+export function Pagination({ data, itemsPerPage }: PaginationProps) {
+  const [currentItems, setCurrentItems] = useState<number[]>([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [itemOffset, setItemOffset] = useState(0);
+
+  //itemOffset - index of first element from array that should be displayed
+  //endOffset - index of last element from array that should be displayed
+
+  //inside useEffect => endOffset is calculeted to know which rows should be displayed on currentPage.
+  //setCurrentItems is called to change currentItems that will be displayed
+  //it's just a simulation of data flow; in real project useEffect could be a place for fetch.
+  useEffect(() => {
+    const endOffset = itemOffset + itemsPerPage;
+    setCurrentItems(data.slice(itemOffset, endOffset));
+    setPageCount(Math.ceil(data.length / itemsPerPage));
+  }, [itemOffset, itemsPerPage, data]);
+
+  //onclick function for each page selector (here it's <li> instead of <button>)
+  //newOffset is created based on selected page. State changes => useEffect runs.
+  const handlePageClick = (event: any) => {
+    const newOffset = (event.selected * itemsPerPage) % data.length;
+    setItemOffset(newOffset);
+  };
+  return (
+    <>
+      <Wrapper>
+        {currentItems?.map((item) => {
+          return (
+            <TransactionWrapper>Transaction {item}</TransactionWrapper>
+          );
+        })}
+      </Wrapper>
+      <ReactPaginate
+        breakLabel="..."
+        nextLabel={
+          <IconStyled icon="chevron_right" color="#ccc" iconSize={15} />
+        }
+        previousLabel={
+          <IconStyled icon="chevron_left" color="#ccc" iconSize={15} />
+        }
+        onPageChange={handlePageClick}
+        pageRangeDisplayed={3}
+        pageCount={pageCount}
+        renderOnZeroPageCount={null}
+        containerClassName="container"
+        previousClassName="previous"
+        nextClassName="next"
+        previousLinkClassName="previous-link"
+        nextLinkClassName="next-link"
+        pageClassName="page"
+        activeClassName="page-active"
+        breakClassName="break"
+      />
+    </>
+  );
+}

--- a/apps/web/app/css/pagination.css
+++ b/apps/web/app/css/pagination.css
@@ -28,6 +28,12 @@
   font-weight: 300;
 }
 
+.disabled {
+  color: #ececec;
+  border-color: #ececec;
+  cursor: not-allowed;
+}
+
 .page,
 .break {
   cursor: pointer;

--- a/apps/web/app/css/pagination.css
+++ b/apps/web/app/css/pagination.css
@@ -1,0 +1,38 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: flex-end;
+  list-style: none;
+  margin-top: 20px;
+  font-size: 1em;
+  gap: 10px;
+}
+
+.next,
+.previous {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid #ececec;
+  cursor: pointer;
+}
+
+.previous-link,
+.next-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 300;
+}
+
+.page,
+.break {
+  cursor: pointer;
+}
+
+.page-active {
+  color: #52a785;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "ka-table": "^8.0.1",
         "material-symbols": "^0.5.0",
         "react-datepicker": "^4.11.0",
+        "react-paginate": "^8.2.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -15820,6 +15821,17 @@
         "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
       }
     },
+    "node_modules/react-paginate": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
+      "dependencies": {
+        "prop-types": "^15"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "license": "MIT",
@@ -31137,6 +31149,14 @@
     },
     "react-onclickoutside": {
       "version": "6.13.0"
+    },
+    "react-paginate": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
+      "requires": {
+        "prop-types": "^15"
+      }
     },
     "react-popper": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ka-table": "^8.0.1",
     "material-symbols": "^0.5.0",
     "react-datepicker": "^4.11.0",
+    "react-paginate": "^8.2.0",
     "zod": "^3.21.4"
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules"],
 }


### PR DESCRIPTION
- task in jira https://tracker.intive.com/jira/browse/PATRO23-272 
- react paginate on github https://github.com/AdeleD/react-paginate and npm https://www.npmjs.com/package/react-paginate

To use it correctly we need to import `ReactPaginate from "react-paginate"`

`<ReactPaginate>` accepts props that allow us to define how pagination should look and work like:

- `onPageChange` - we can pass function that will be called when user changes the page,
- `pageCount` -  we can determine the amount of pages that will be available,
- `renderOnZeroPageCount` - we can define what will be rendered when there are 0 pages. If we don’t want to render anything, `null` should be passed,
- `breakLabel`, `nextLabel` , `previousLabel` props **are able to accept styled components** as labels for pagination's elements,
- **behaviour of three dots** -> prop `pageRangeDisplayed` allows to define how many pages should be visible before or after break label (...). F.ex: `pageRangeDisplayed={3}` => 3 pages are displayed before and after break label, depends where user click. When user change pages, the position of break label changes as well in proper moment to preserve the `pageRangeDisplayed`, 
- props such as `pageClassName` , `activeClassName`, `nextLinkClassName` etc. allow to pass class names in the aim of customizing pagination's elements (css styling).

Demo is on the main page of  application 👀

**Update** 💥 

1. Kudos @mpiwonski  for comment about disabled buttons.  In PR #71 @Noshi96 already discovered option for making previous/next button disabled. To achieve it, prop `disabledClassName` must be added with our class name for proper styling.
 
2. **Pagination behaviour with more items** (= more pages) -> Pagination can expand up to 10 visible pages. To preserve this, when there is more than 10 pages, two pairs of `...` appear. By clicking it, we can jump over the amount of pages that was set in `pageRangeDisplayed`.  

