### PR TITLE
fix: transactions table #P23-282

### DIFF
--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
@@ -2,17 +2,22 @@ import styled from "styled-components";
 import { CurrencyAmount } from "ui/CurrencyAmount";
 
 export const TableWrapperStyled = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
+  margin-left: -48px;
+  margin-right: -48px;
 
   // table styles
   .ka-table {
-    width: 100%;
+    tr > :first-child {
+      padding-left: 48px;
+    }
+
+    tr > :last-child {
+      padding-right: 0;
+    }
   }
 
   .ka-empty-cell {
-    width: 1px;
+    width: 48px;
   }
 
   // header styles
@@ -55,9 +60,9 @@ export const TableWrapperStyled = styled.div`
     cursor: pointer;
   }
 
-  // table body
-  tbody > tr:first-child > td {
-    padding-top: 16px;
+  // center "Creator" and "Amount" headers
+  .ka-thead-cell#creator .ka-thead-cell-content, .ka-thead-cell#amount .ka-thead-cell-content {
+    justify-content: center;
   }
 
   // group row styles
@@ -67,6 +72,10 @@ export const TableWrapperStyled = styled.div`
 
   .ka-group-row {
     background-color: ${({ theme }) => theme.transactionsTable.background};
+
+    > td {
+      padding-top: 24px;
+    }
   }
 
   .ka-group-cell {
@@ -83,10 +92,19 @@ export const TableWrapperStyled = styled.div`
   // normal row styles
   .ka-row {
     border: none;
-    border-top: 1px solid ${({ theme }) => theme.transactionsTable.rowSeparator};
+
+    td {
+      border-top: 1px solid
+        ${({ theme }) => theme.transactionsTable.rowSeparator};
+    }
+
+    td:first-child,
+    td:last-child {
+      border-top: none;
+    }
   }
 
-  .ka-group-row + .ka-row {
+  .ka-group-row + .ka-row td {
     border-top: none;
   }
 
@@ -99,8 +117,7 @@ export const TableWrapperStyled = styled.div`
   }
 
   .ka-cell {
-    text-align: left;
-    padding-left: 0;
+    padding: 17px 8px 17px 0;
   }
 
   // avatar styles
@@ -113,5 +130,5 @@ export const TableWrapperStyled = styled.div`
 export const StyledCurrencyAmount = styled(CurrencyAmount)`
   display: block;
   text-align: right;
-  font-family: unset; // component adds Signika font so I need to reset it
+  font-family: unset; // component adds Signika font
 `;

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
@@ -17,7 +17,7 @@ export const TableWrapperStyled = styled.div`
   }
 
   .ka-empty-cell {
-    width: 48px;
+    width: 1px;
   }
 
   // header styles
@@ -98,6 +98,7 @@ export const TableWrapperStyled = styled.div`
         ${({ theme }) => theme.transactionsTable.rowSeparator};
     }
 
+    // no border on first and last empty columns
     td:first-child,
     td:last-child {
       border-top: none;

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
@@ -60,9 +60,8 @@ export const TableWrapperStyled = styled.div`
     cursor: pointer;
   }
 
-  // center "Creator" and "Amount" headers
-  .ka-thead-cell#creator .ka-thead-cell-content,
-  .ka-thead-cell#amount .ka-thead-cell-content {
+  // center "Creator" header
+  .ka-thead-cell#creator .ka-thead-cell-content {
     justify-content: center;
   }
 
@@ -131,6 +130,6 @@ export const TableWrapperStyled = styled.div`
 
 export const StyledCurrencyAmount = styled(CurrencyAmount)`
   display: block;
-  text-align: right;
+  text-align: left;
   font-family: unset; // component adds Signika font
 `;

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.styled.tsx
@@ -61,7 +61,8 @@ export const TableWrapperStyled = styled.div`
   }
 
   // center "Creator" and "Amount" headers
-  .ka-thead-cell#creator .ka-thead-cell-content, .ka-thead-cell#amount .ka-thead-cell-content {
+  .ka-thead-cell#creator .ka-thead-cell-content,
+  .ka-thead-cell#amount .ka-thead-cell-content {
     justify-content: center;
   }
 

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
@@ -17,10 +17,6 @@ import { TransactionDropdownMenu } from "ui/TransactionDropdownMenu";
 import dayjs from "dayjs";
 import isToday from "dayjs/plugin/isToday";
 import isYesterday from "dayjs/plugin/isYesterday";
-import localizedFormat from "dayjs/plugin/localizedFormat";
-// import "dayjs/locale/pl";
-// import "dayjs/locale/en-GB";
-// import "dayjs/locale/en";
 
 import { useEffect, useState } from "react";
 import {
@@ -129,8 +125,6 @@ export const TransactionsTable = ({
 
   const getDayName = (timestamp: number, locale: string) => {
     dayjs.extend(isToday);
-    // dayjs.extend(localizedFormat);
-    // dayjs.extend(localizedFormat);
     dayjs.extend(isYesterday);
 
     const date = dayjs(timestamp);

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from "lib/hooks";
 import { Budget, Transaction } from "../../../../lib/types";
 import { Table } from "ka-table";
 import { DataType } from "ka-table/enums";
+import { Column } from "ka-table/models";
 import { Icon } from "ui/Icon";
 import { CategoryIcon } from "ui/CategoryIcon";
 import { Avatar } from "ui/Avatar";
@@ -26,7 +27,6 @@ import {
   TableWrapperStyled,
   StyledCurrencyAmount,
 } from "./TransactionsTable.styled";
-import { Column } from "ka-table/models";
 
 const columns = [
   {
@@ -34,45 +34,75 @@ const columns = [
     title: "Category",
     isSortable: true,
     dataType: DataType.Object,
-    width: 120,
+    style: {
+      // backgroundColor: "Wheat",
+      verticalAlign: "middle",
+      lineHeight: 0,
+    },
+    width: "19%",
   },
   {
     key: "description",
     title: "Name",
     isSortable: true,
     dataType: DataType.String,
-    width: 170,
+    // style: { backgroundColor: "PaleTurquoise" },
+    width: "22%",
   },
   {
     key: "status",
     title: "Status",
     isSortable: true,
     dataType: DataType.String,
+    // style: { backgroundColor: "RosyBrown" },
+    width: "18%",
   },
   {
     key: "amount",
     title: "Amount",
     isSortable: true,
     dataType: DataType.Number,
-    width: 140,
+    // style: { backgroundColor: "LightBlue" },
+    width: "23%",
   },
   {
     key: "creator",
     title: "Creator",
     isSortable: true,
     dataType: DataType.Object,
-    width: 80,
-    style: { textAlign: "center", verticalAlign: "middle", lineHeight: 0 },
+    style: {
+      // backgroundColor: "Coral",
+      textAlign: "center",
+      verticalAlign: "middle",
+      lineHeight: 0,
+      paddingLeft: "8px",
+      paddingRight: "8px",
+    },
+    width: "13%",
   },
   {
     key: "editColumn",
-    width: 30,
+    style: {
+      // backgroundColor: "LightPink",
+      textAlign: "center",
+      verticalAlign: "middle",
+      lineHeight: 0,
+      paddingLeft: "8px",
+      paddingRight: "8px",
+    },
+    width: "5%",
   },
   {
     key: "date",
     title: "Date",
     isSortable: false,
     dataType: DataType.Number,
+  },
+  {
+    key: "empty",
+    title: "",
+    isSortable: false,
+    width: '48px'
   },
 ] as Column[];
 
@@ -99,6 +129,7 @@ export const TransactionsTable = ({
 
   const getDayName = (timestamp: number, locale: string) => {
     dayjs.extend(isToday);
+    // dayjs.extend(localizedFormat);
     // dayjs.extend(localizedFormat);
     dayjs.extend(isYesterday);
 
@@ -182,6 +213,9 @@ export const TransactionsTable = ({
           },
           headCellContent: {
             content: ({ column }) => {
+              if ( column.key === 'empty') {
+                return null;
+              }
               return (
                 <>
                   <span>{column.title}</span>

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionsTable.tsx
@@ -98,7 +98,7 @@ const columns = [
     key: "empty",
     title: "",
     isSortable: false,
-    width: '48px'
+    width: "48px",
   },
 ] as Column[];
 
@@ -141,15 +141,15 @@ export const TransactionsTable = ({
 
   const dropdownMenuItems = [
     {
-      ComponentToRender: "Edit",
+      ComponentToRender: <div>Edit</div>,
       id: "edit-budget",
     },
     {
-      ComponentToRender: "Clone",
+      ComponentToRender: <div>Clone</div>,
       id: "clone-budget",
     },
     {
-      ComponentToRender: "Remove",
+      ComponentToRender: <div>Remove</div>,
       id: "remove-budget",
     },
   ];
@@ -207,7 +207,7 @@ export const TransactionsTable = ({
           },
           headCellContent: {
             content: ({ column }) => {
-              if ( column.key === 'empty') {
+              if (column.key === "empty") {
                 return null;
               }
               return (

--- a/packages/ui/TransactionDropdownMenu/index.tsx
+++ b/packages/ui/TransactionDropdownMenu/index.tsx
@@ -2,11 +2,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Icon } from "ui";
 import styled from "styled-components";
-import { ReactElement, ReactNode } from "react";
+import { ReactElement } from "react";
 
 //type for every item in DropdownMenu
 type DropdownMenuSingleItem = {
-  ComponentToRender?: ReactNode;
+  ComponentToRender?: ReactElement;
   id: string;
 };
 

--- a/packages/ui/TransactionDropdownMenu/index.tsx
+++ b/packages/ui/TransactionDropdownMenu/index.tsx
@@ -82,7 +82,7 @@ export const TransactionDropdownMenu = ({
   ariaLabel,
 }: TransactionDropdownMenuProps) => {
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root modal={false}>
       <DropdownMenuTriggerStyled asChild>
         <button aria-label={ariaLabel}>
           <IconStyled icon="more_vert" />


### PR DESCRIPTION
## Fixes for transactions' table
task: https://tracker.intive.com/jira/browse/PATRO23-282
### What changed ✏️ 
- **column sizes are set as %** - there is a difference in columns' width when you compare it to the design. This is due to the fact, that it has to display well on a variety of screen sizes. Setting it to widths similar to the ones on the design would always produce some problems on different widths, especially around breakpoints. I tried to find the best widths that work well on a bigger screen, around 1025px, and down to 768px. Below that we would need additional design and probably some columns should be hidden then.
- **other differences compared to design:**
   - as we discussed, the "Creator" column (header and contents) is centered (it is to the left in the design)
   - I centered also the "Amount" header (which seems to be to the left in the design), so there is a smaller gap between the header and column's contents. It could maybe be to the right, but on wider screens, it did not look good to have such a big white space between the "Status" and "Amount" headers
- **header bottom border** - I added styles to make it look like in the design (full width of the `Card`)
- **fix for table shift** - I fixed the table shift caused by `TransactionDropdownMenu` hiding the scrollbar
### Issues 😢 
It does not look great on a very wide screen. There probably should be some limits to `Card` width on such a screen, or some other way around it, but again, there is no design for that

<img width="949" alt="image" src="https://user-images.githubusercontent.com/80450315/235513962-d9c95c62-ad85-48f6-92a2-f1386a3f70b5.png">

### Things that might look weird but aren't 😅
- negative margins on `TableWrapper` - done to have a bottom border of the table header be of the full width of the `Card`
<img width="286" alt="image" src="https://user-images.githubusercontent.com/80450315/235515838-bfa0d70e-4c33-4456-accd-7367b64640ba.png">

- creating a grouping row adds an empty cell at the beginning of each row - it had to be sized to 1px instead of having `display: none` since the latter would for some reason shift the table layout to the left and add some space on the right 🙄
<img width="125" alt="image" src="https://user-images.githubusercontent.com/80450315/235516191-89ccd96c-f7a4-490c-8a38-44f07104ddc1.png">

- each column has a commented-out line that adds a background color to it, so it is easier to see how columns resize - I am leaving it for now, will remove it before merging

