### PR TITLE
fix: add missing link in login form #P23-304

### DIFF
--- a/apps/storybook/stories/FormFooter.stories.tsx
+++ b/apps/storybook/stories/FormFooter.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { FormFooter } from "ui";
+
+export default {
+  title: "FormFooter",
+  component: FormFooter,
+} as ComponentMeta<typeof FormFooter>;
+
+const Template: ComponentStory<typeof FormFooter> = ({ ...args }) => (
+  <FormFooter {...args} />
+);
+
+export const Simple = Template.bind({});
+Simple.args = {
+  basicText: "Already have an account?",
+  linkText: "Log in",
+  href: "/sign-in",
+};

--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -3,7 +3,7 @@
 import { Field, Form } from "houseform";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ErrorMessage, Button, Input, LinkComponent } from "ui";
+import { ErrorMessage, Button, Input, FormFooter } from "ui";
 import styled from "styled-components";
 import { z } from "zod";
 import { useTranslate } from "lib/hooks";
@@ -48,12 +48,6 @@ const ErrorSuportingMsg = styled.div`
   left: 10px;
   color: #b3261e;
   font-size: small;
-`;
-
-const FooterStyled = styled.div`
-  font-size: 16px;
-  line-height: 150%;
-  margin-top: 42px;
 `;
 
 export default function SignInPage() {
@@ -138,12 +132,11 @@ export default function SignInPage() {
             <Button onClick={submit} type="submit" fullWidth>
               {t(form.submitButton)}
             </Button>
-            <FooterStyled>
-              {t(form.footer)}{" "}
-              <LinkComponent href="/sign-up">
-                {t(form.footerLink)}
-              </LinkComponent>
-            </FooterStyled>
+            <FormFooter
+              basicText={t(form.footer)}
+              linkText={t(form.footerLink)}
+              href="/sign-up"
+            />
           </form>
         </FormWrapper>
       )}

--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -3,7 +3,7 @@
 import { Field, Form } from "houseform";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ErrorMessage, Button, Input } from "ui";
+import { ErrorMessage, Button, Input, LinkComponent } from "ui";
 import styled from "styled-components";
 import { z } from "zod";
 import { useTranslate } from "lib/hooks";
@@ -48,6 +48,12 @@ const ErrorSuportingMsg = styled.div`
   left: 10px;
   color: #b3261e;
   font-size: small;
+`;
+
+const FooterStyled = styled.div`
+  font-size: 16px;
+  line-height: 150%;
+  margin-top: 42px;
 `;
 
 export default function SignInPage() {
@@ -132,6 +138,12 @@ export default function SignInPage() {
             <Button onClick={submit} type="submit" fullWidth>
               {t(form.submitButton)}
             </Button>
+            <FooterStyled>
+              {t(form.footer)}{" "}
+              <LinkComponent href="/sign-up">
+                {t(form.footerLink)}
+              </LinkComponent>
+            </FooterStyled>
           </form>
         </FormWrapper>
       )}

--- a/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
+++ b/apps/web/app/(regflow)/sign-up/EmailScreen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Field, Form } from "houseform";
-import { Button, Input, LinkComponent } from "ui";
+import { Button, Input, FormFooter } from "ui";
 import styled from "styled-components";
 import { z } from "zod";
 import { useTranslate } from "lib/hooks";
@@ -55,12 +55,11 @@ export const EmailScreen = ({ onNext, userInfo = "" }: EmailScreenProps) => {
           <Button onClick={submit} type="submit" fullWidth>
             {t(emailScreen.buttonNext)}
           </Button>
-          <FooterStyled>
-            {t(emailScreen.footer)}{" "}
-            <LinkComponent href="/sign-in">
-              {t(emailScreen.footerLink)}
-            </LinkComponent>
-          </FooterStyled>
+          <FormFooter
+            basicText={t(emailScreen.footer)}
+            linkText={t(emailScreen.footerLink)}
+            href="/sign-in"
+          />
         </FormWrapper>
       )}
     </Form>

--- a/apps/web/lib/dictionary.tsx
+++ b/apps/web/lib/dictionary.tsx
@@ -104,6 +104,16 @@ const dictionary = {
         },
       },
       submitButton: { en: "Log In", pl: "Zaloguj", fr: "Se connecter" },
+      footer: {
+        en: "Don't have an account?",
+        pl: "Nie posiadasz konta?",
+        fr: "N'avez-vous pas de compte ?",
+      },
+      footerLink: {
+        en: "Sign up",
+        pl: "Zarejestruj się",
+        fr: "Inscrivez-vous",
+      },
     },
   },
   SignUpPage: {
@@ -462,9 +472,13 @@ const dictionary = {
       dateFormats: { en: "en-GB", pl: "pl", fr: "fr-FR" },
     },
     createButton: {
-      label: { en: "Create", pl: "Utwórz", fr: "Créer"},
-      newIncome: { en: "New income", pl: "Nowy wpływ", fr: "Nouveaux revenus"},
-      newExpense: { en: "New expense", pl: "Nowy wydatek", fr: "Nouvelle dépense"},
+      label: { en: "Create", pl: "Utwórz", fr: "Créer" },
+      newIncome: { en: "New income", pl: "Nowy wpływ", fr: "Nouveaux revenus" },
+      newExpense: {
+        en: "New expense",
+        pl: "Nowy wydatek",
+        fr: "Nouvelle dépense",
+      },
     },
     transactionsTable: {
       groupRowDays: {

--- a/packages/ui/FormFooter/index.tsx
+++ b/packages/ui/FormFooter/index.tsx
@@ -1,12 +1,11 @@
 "use client";
-import { ReactElement } from "react";
 import styled from "styled-components";
 import { LinkComponent } from "ui";
 
 type FormFooterProps = {
   basicText: string;
   linkText: string;
-  href:string;
+  href: string;
 };
 
 const FormFooterStyled = styled.div`
@@ -23,7 +22,7 @@ const TextStyled = styled.span`
   color: ${({ theme }) => theme.formfooter.text};
 `;
 
-export const FormFooter = ({ basicText, linkText,href }: FormFooterProps) => {
+export const FormFooter = ({ basicText, linkText, href }: FormFooterProps) => {
   return (
     <FormFooterStyled>
       <TextStyled>{basicText}</TextStyled>

--- a/packages/ui/FormFooter/index.tsx
+++ b/packages/ui/FormFooter/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { ReactElement } from "react";
+import styled from "styled-components";
+import { LinkComponent } from "ui";
+
+type FormFooterProps = {
+  basicText: string;
+  linkText: string;
+  href:string;
+};
+
+const FormFooterStyled = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  line-height: 150%;
+  margin-top: 42px;
+`;
+
+const TextStyled = styled.span`
+  color: ${({ theme }) => theme.formfooter.text};
+`;
+
+export const FormFooter = ({ basicText, linkText,href }: FormFooterProps) => {
+  return (
+    <FormFooterStyled>
+      <TextStyled>{basicText}</TextStyled>
+      <LinkComponent href={href}>{linkText}</LinkComponent>
+    </FormFooterStyled>
+  );
+};

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -25,3 +25,4 @@ export { BudgetIcon } from "./BudgetIcon";
 export { CurrencyAmount } from "./CurrencyAmount";
 export { CategoryIcon } from "./CategoryIcon";
 export { ButtonWithDropdown } from "./ButtonWithDropdown";
+export { FormFooter } from "./FormFooter";

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -152,7 +152,7 @@ export const theme = {
       activeColor: colors.Teal10,
       inactiveColor: colors.Neutral8,
       activeBackground: colors.Teal1,
-      inactiveBackground: "transparent",
+      inactiveBackground: colors.BasicTransparent,
       hoverAndFocusBackground: colors.Teal1,
       focusOutline: colors.Teal10,
     },
@@ -263,6 +263,9 @@ export const theme = {
       foreground: colors.Supporting13,
       background: colors.Supporting12,
     },
+  },
+  formfooter: {
+    text: "#3e4c59",
   },
 };
 


### PR DESCRIPTION
ticket: https://tracker.intive.com/jira/browse/PATRO23-304

- add missing text with link in log-in form to be able to move to sign-up page ➡️ 
- dictionnary has been updated! 📖 

Element that was missing: 
<img width="206" alt="image" src="https://user-images.githubusercontent.com/93678778/236900198-1e82073c-9a89-484b-ad94-09a428ed8af5.png">


<h2>Update 📣 </h2>

Due to acheive proper styles from design and avoid code repetition,  component `<FormFooter>` has been created. It receives props such as: 

```typescript
type FormFooterProps = {
  basicText: string;
  linkText: string;
  href:string;
};
```  
In connection with this change, component was added to Storybook as well  📖 


