### PR TITLE
feat: trend chip #P23-309

### DIFF
--- a/apps/storybook/stories/TrendChip.stories.tsx
+++ b/apps/storybook/stories/TrendChip.stories.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { TrendChip } from "ui";
+import styled from "styled-components";
+
+export default {
+  title: "TrendChip",
+  component: TrendChip,
+} as ComponentMeta<typeof TrendChip>;
+
+//imitation of parent component for proper display on storybook
+const TrendChipWrapper = styled.div`
+  width: 80px;
+`;
+
+const Template: ComponentStory<typeof TrendChip> = ({ ...args }) => (
+  <TrendChipWrapper>
+    <TrendChip {...args} />
+  </TrendChipWrapper>
+);
+
+export const PositiveValue = Template.bind({});
+PositiveValue.args = {
+  value: 20,
+};
+
+export const NegativeValue = Template.bind({});
+NegativeValue.args = {
+  value: -20,
+};

--- a/apps/storybook/stories/TrendChip.stories.tsx
+++ b/apps/storybook/stories/TrendChip.stories.tsx
@@ -10,7 +10,7 @@ export default {
 
 //imitation of parent component for proper display on storybook
 const TrendChipWrapper = styled.div`
-  width: 80px;
+  width: 5%;
 `;
 
 const Template: ComponentStory<typeof TrendChip> = ({ ...args }) => (

--- a/apps/storybook/stories/TrendChip.stories.tsx
+++ b/apps/storybook/stories/TrendChip.stories.tsx
@@ -1,30 +1,31 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TrendChip } from "ui";
-import styled from "styled-components";
 
 export default {
   title: "TrendChip",
   component: TrendChip,
 } as ComponentMeta<typeof TrendChip>;
 
-//imitation of parent component for proper display on storybook
-const TrendChipWrapper = styled.div`
-  width: 5%;
-`;
-
 const Template: ComponentStory<typeof TrendChip> = ({ ...args }) => (
-  <TrendChipWrapper>
-    <TrendChip {...args} />
-  </TrendChipWrapper>
+  <TrendChip {...args} />
 );
 
+//in stories ariaLabel is hardcoded
 export const PositiveValue = Template.bind({});
 PositiveValue.args = {
   value: 20,
+  ariaLabel: `Your budget's percentage growth is 20%`,
 };
 
 export const NegativeValue = Template.bind({});
 NegativeValue.args = {
   value: -20,
+  ariaLabel: `Your budget's percentage growth is -20%`,
+};
+
+export const ZeroValue = Template.bind({});
+ZeroValue.args = {
+  value: 0,
+  ariaLabel: `Your budget's percentage growth is 0%`,
 };

--- a/apps/web/lib/dictionary.tsx
+++ b/apps/web/lib/dictionary.tsx
@@ -500,7 +500,16 @@ const dictionary = {
       },
     },
   },
-  ReportsPage: { title: { en: "Reports page", pl: "Raporty", fr: "Rapports" } },
+  ReportsPage: {
+    title: { en: "Reports page", pl: "Raporty", fr: "Rapports" },
+    trendChip: {
+      text: {
+        en: "Your budget's percentage growth is ",
+        pl: "Wzrost procentowy twojego budżetu wynosi ",
+        fr: "Le pourcentage de croissance de votre budget est de ",
+      },
+    },
+  },
   SettingsPage: {
     title: { en: "Settings page", pl: "Ustawienia", fr: "Paramètres" },
   },

--- a/packages/ui/FormFooter/index.tsx
+++ b/packages/ui/FormFooter/index.tsx
@@ -19,7 +19,7 @@ const FormFooterStyled = styled.div`
 `;
 
 const TextStyled = styled.span`
-  color: ${({ theme }) => theme.formfooter.text};
+  color: ${({ theme }) => theme.formFooter.text};
 `;
 
 export const FormFooter = ({ basicText, linkText, href }: FormFooterProps) => {

--- a/packages/ui/Icon/index.tsx
+++ b/packages/ui/Icon/index.tsx
@@ -54,7 +54,8 @@ export type IconType =
   | "done"
   | "priority_high"
   | "navigate_before"
-  | "navigate_next";
+  | "navigate_next"
+  | "trending_flat";
 
 type styledIconProps = {
   color?: string;

--- a/packages/ui/TrendChip/index.tsx
+++ b/packages/ui/TrendChip/index.tsx
@@ -1,9 +1,11 @@
 "use client";
 import styled from "styled-components";
 import { Icon } from "ui";
+import { IconType } from "../Icon";
 
 export type TrendChipProps = {
   value: number;
+  ariaLabel?: string;
 } & React.HTMLProps<HTMLDivElement>;
 
 export const TrendChipStyled = styled.div<TrendChipProps>`
@@ -11,36 +13,46 @@ export const TrendChipStyled = styled.div<TrendChipProps>`
   justify-content: center;
   align-content: center;
   gap: 4px;
+  width: fit-content;
   line-height: 16px;
   font-size: 12px;
-  padding: 2px 28px;
+  padding: 2px 8px;
   font-weight: 600;
   border-radius: 30px;
-  color: ${({ value, theme }) =>
-    value > 0
-      ? theme.trendChip.positiveValue.color
-      : theme.trendChip.negativeValue.color};
+  color: ${({ value, theme }) => {
+    if (value < 0) {
+      return theme.trendChip.negativeValue.color;
+    } else if (value > 0) {
+      return theme.trendChip.positiveValue.color;
+    }
+    return theme.trendChip.zeroValue.color;
+  }};
   border: 2px solid
-    ${({ value, theme }) =>
-      value > 0
-        ? theme.trendChip.positiveValue.border
-        : theme.trendChip.negativeValue.border};
+    ${({ value, theme }) => {
+      if (value < 0) {
+        return theme.trendChip.negativeValue.border;
+      } else if (value > 0) {
+        return theme.trendChip.positiveValue.border;
+      }
+      return theme.trendChip.zeroValue.border;
+    }};
 `;
 
-export const TrendChip = ({ value }: TrendChipProps) => {
-  const displayedIcon =
-    value > 0 ? (
-      <Icon icon="trending_up" iconSize={15} />
-    ) : (
-      <Icon icon="trending_down" iconSize={15} />
-    );
-  const displayedValue =
-    value > 0 ? <span>{value}%</span> : <span>{Math.abs(value)}%</span>;
+export const TrendChip = ({ value, ariaLabel }: TrendChipProps) => {
+  const iconName = (): IconType => {
+    if (value === 0) return "trending_flat";
+    if (value < 0) return "trending_down";
+    return "trending_up";
+  };
+
+  //because we can't use dictionnary in /ui folder, ariaLabel is passed by prop.
+  //example of use: in the place of component's consumption : ariaLabel={t(trendChip.text) + `${value}%`}/>
+  //with that, we can use the dictionnary and pass proper value dynamically
 
   return (
-    <TrendChipStyled value={value}>
-      {displayedIcon}
-      {displayedValue}
+    <TrendChipStyled role="status" value={value} aria-label={ariaLabel}>
+      <Icon icon={iconName()} iconSize={15} />
+      <span>{Math.abs(value)}%</span>
     </TrendChipStyled>
   );
 };

--- a/packages/ui/TrendChip/index.tsx
+++ b/packages/ui/TrendChip/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+import styled from "styled-components";
+import { Icon } from "ui";
+
+export type TrendChipProps = {
+  value: number;
+} & React.HTMLProps<HTMLDivElement>;
+
+export const TrendChipStyled = styled.div<TrendChipProps>`
+  font-weight: 600;
+  font-size: 12px;
+  border-radius: 16px;
+  padding: 4px 16px;
+  color: ${({ value, theme }) =>
+    value > 0 ? theme.trendChip.positiveValue : theme.trendChip.negativeValue};
+  border: 1px solid
+    ${({ value, theme }) =>
+      value > 0
+        ? theme.trendChip.positiveValue
+        : theme.trendChip.negativeValue};
+`;
+export const Chip = ({ value }: TrendChipProps) => {
+  const displayedIcon =
+    value > 0 ? <Icon icon="trending_up" /> : <Icon icon="trending_down" />;
+  const displayedValue = value > 0 ? <p>{value}</p> : <p>{Math.abs(value)}</p>;
+
+  return (
+    <TrendChipStyled value={value}>
+      {displayedIcon}
+      {displayedValue}
+    </TrendChipStyled>
+  );
+};

--- a/packages/ui/TrendChip/index.tsx
+++ b/packages/ui/TrendChip/index.tsx
@@ -8,19 +8,23 @@ export type TrendChipProps = {
 
 export const TrendChipStyled = styled.div<TrendChipProps>`
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   align-content: center;
-  padding: 4px 16px;
-  font-weight: 600;
+  gap: 4px;
+  line-height: 16px;
   font-size: 12px;
+  padding: 2px 28px;
+  font-weight: 600;
   border-radius: 30px;
   color: ${({ value, theme }) =>
-    value > 0 ? theme.trendChip.positiveValue : theme.trendChip.negativeValue};
+    value > 0
+      ? theme.trendChip.positiveValue.color
+      : theme.trendChip.negativeValue.color};
   border: 2px solid
     ${({ value, theme }) =>
       value > 0
-        ? theme.trendChip.positiveValue
-        : theme.trendChip.negativeValue};
+        ? theme.trendChip.positiveValue.border
+        : theme.trendChip.negativeValue.border};
 `;
 
 export const TrendChip = ({ value }: TrendChipProps) => {
@@ -31,7 +35,7 @@ export const TrendChip = ({ value }: TrendChipProps) => {
       <Icon icon="trending_down" iconSize={15} />
     );
   const displayedValue =
-    value > 0 ? <span>{value}</span> : <span>{Math.abs(value)}</span>;
+    value > 0 ? <span>{value}%</span> : <span>{Math.abs(value)}%</span>;
 
   return (
     <TrendChipStyled value={value}>

--- a/packages/ui/TrendChip/index.tsx
+++ b/packages/ui/TrendChip/index.tsx
@@ -7,22 +7,31 @@ export type TrendChipProps = {
 } & React.HTMLProps<HTMLDivElement>;
 
 export const TrendChipStyled = styled.div<TrendChipProps>`
+  display: flex;
+  justify-content: space-around;
+  align-content: center;
+  padding: 4px 16px;
   font-weight: 600;
   font-size: 12px;
-  border-radius: 16px;
-  padding: 4px 16px;
+  border-radius: 30px;
   color: ${({ value, theme }) =>
     value > 0 ? theme.trendChip.positiveValue : theme.trendChip.negativeValue};
-  border: 1px solid
+  border: 2px solid
     ${({ value, theme }) =>
       value > 0
         ? theme.trendChip.positiveValue
         : theme.trendChip.negativeValue};
 `;
-export const Chip = ({ value }: TrendChipProps) => {
+
+export const TrendChip = ({ value }: TrendChipProps) => {
   const displayedIcon =
-    value > 0 ? <Icon icon="trending_up" /> : <Icon icon="trending_down" />;
-  const displayedValue = value > 0 ? <p>{value}</p> : <p>{Math.abs(value)}</p>;
+    value > 0 ? (
+      <Icon icon="trending_up" iconSize={15} />
+    ) : (
+      <Icon icon="trending_down" iconSize={15} />
+    );
+  const displayedValue =
+    value > 0 ? <span>{value}</span> : <span>{Math.abs(value)}</span>;
 
   return (
     <TrendChipStyled value={value}>

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -26,3 +26,4 @@ export { CurrencyAmount } from "./CurrencyAmount";
 export { CategoryIcon } from "./CategoryIcon";
 export { ButtonWithDropdown } from "./ButtonWithDropdown";
 export { FormFooter } from "./FormFooter";
+export { TrendChip } from "./TrendChip";

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -264,9 +264,13 @@ export const theme = {
       background: colors.Supporting12,
     },
   },
-  formfooter: {
+  formFooter: {
     text: "#3e4c59",
   },
+  trendChip:{
+    positiveValue: colors.Supporting7 ,
+    negativeValue: colors.Supporting4
+  }
 };
 
 export type ThemeType = typeof theme;

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -282,6 +282,10 @@ export const theme = {
       color: "#d41111",
       border: "rgba(212,17,17,0.5)",
     },
+    zeroValue: {
+      color: colors.Neutral6,
+      border: colors.Neutral2,
+    },
   },
 };
 

--- a/packages/ui/theme.tsx
+++ b/packages/ui/theme.tsx
@@ -273,10 +273,16 @@ export const theme = {
   formFooter: {
     text: "#3e4c59",
   },
-  trendChip:{
-    positiveValue: colors.Supporting7 ,
-    negativeValue: colors.Supporting4
-  }
+  trendChip: {
+    positiveValue: {
+      color: colors.Supporting7,
+      border: "rgba(73,173,31,0.5)",
+    },
+    negativeValue: {
+      color: "#d41111",
+      border: "rgba(212,17,17,0.5)",
+    },
+  },
 };
 
 export type ThemeType = typeof theme;


### PR DESCRIPTION
ticket: https://tracker.intive.com/jira/browse/PATRO23-309

<h3>Overview 👀 </h3>
Trend chip component that accepts value in props. Depending on a positive or negative value, it takes proper color and icon.
 <h4>Update! 💥  </h4> Component takes as well `ariaLabel` prop.
 
```typescript
export type TrendChipProps = {
  value: number;
  ariaLabel: string;
} & React.HTMLProps<HTMLDivElement>;
```  



<h2> Update: problem resolved ✔️ </h2>
<h3>Problem 🤔</h3>

I tried to imagine a situation where user can get really high income, and then value could be quite long. In that situation, even though TrendChip doesn't have width, but only paddings, the value goes beyond it's border. Now this problem is caused by wrapper in storybook, so the width depends on parent element. Should it be that way, or maybe we need to find another solution?


<h3>Component's design: </h3>

<img width="70" alt="image" src="https://github.com/intive/patronage2023-js/assets/93678778/e514f5f7-8fde-4512-a90b-af2fbc9b6fb7">
<img width="71" alt="image" src="https://github.com/intive/patronage2023-js/assets/93678778/d77f28b8-eb91-4692-a49e-148346da85c7">
  