### PR TITLE
fix: next-auth middleware fix and main page refactor#P23-196

### DIFF
--- a/apps/web/app/(navigation)/(singleCard)/MainPageTranslated.tsx
+++ b/apps/web/app/(navigation)/(singleCard)/MainPageTranslated.tsx
@@ -2,7 +2,7 @@
 
 import { TypoStyled, LinkStyled } from "app/(navigation)/HomePageComponents";
 import { useTranslate } from "lib/hooks";
-import { signOut, useSession } from "next-auth/react";
+import { signIn, signOut, useSession } from "next-auth/react";
 import { Button } from "ui";
 import styled from "styled-components";
 
@@ -20,18 +20,19 @@ export const MainPageTranslated = () => {
     <ContentWrapperStyled>
       <TypoStyled>{t(dict.welcomeText)}</TypoStyled>
       <LinkStyled href="/sign-up">{t(dict.createAccountLink)}</LinkStyled>
-      <LinkStyled href="/sign-in">Sign in</LinkStyled>
-      <br />
-      <Button onClick={() => signOut()}>Log out</Button>
       <br />
       {data ? (
-        <p>
-          User: {data.user.name}, <br /> Avatar: {data.user.image}, <br />{" "}
-          AccessToken:
-          {data.user.accessToken.substring(0, 30)}...
-        </p>
+        <>
+          <Button onClick={() => signOut()}>Log out</Button>
+          <br />
+          <p>
+            User: {data.user.name}, <br /> Avatar: {data.user.image}, <br />{" "}
+            AccessToken:
+            {data.user.accessToken.substring(0, 30)}...
+          </p>
+        </>
       ) : (
-        <p>Please log in</p>
+        <Button onClick={() => signIn()}>Sign in</Button>
       )}
     </ContentWrapperStyled>
   );

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -69,15 +69,5 @@ export const authOptions: NextAuthOptions = {
     signOut: "/sign-in/",
     error: "/sign-in/",
   },
-  jwt: {
-    async encode({ token, secret }) {
-      // @ts-ignore
-      return jwt.sign(token, secret);
-    },
-    async decode({ token, secret }) {
-      // @ts-ignore
-      return jwt.verify(token, secret);
-    },
-  },
 };
 export default NextAuth(authOptions);


### PR DESCRIPTION
Small middleware fix which removes custom encoding method of JWT token - token is encoded by default.
Small landing page refactor with changing button based on the logged user informations.

I've kept the unnecessary data on the frontpage for now as an example on how to use useSession hook.