### PR TITLE
fix: email resets after pressing enter in form #P23-368

### DIFF
--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -46,6 +46,7 @@ export const Input = forwardRef(
       if (type === "password") {
         return (
           <StyledIcon
+            type="button"
             onClick={(event) => {
               event.preventDefault();
               inputRef.current?.focus();
@@ -69,6 +70,7 @@ export const Input = forwardRef(
       if (value && onInputCleared) {
         return (
           <StyledIcon
+            type="button"
             onClick={(event) => {
               event.preventDefault();
               inputRef.current?.focus();


### PR DESCRIPTION
## Problem: 🎯 After clicking enter inside sign-in form, the email input was reset.

#### Ticket: https://tracker.intive.com/jira/browse/PATRO23-368

### Why does it happen ❓ 
In forms, clicking enter triggers a button, which is used to trigger submit.
In our case, the icons inside the inputs are buttons, so clicking enter would trigger the first button in the queue (1. Clear input button, 2. Show/hide password button, 3. Submit button). If we remove the clear function, the next button is triggered.

### How can this be prevented ❓ 
```tsx
<button type="button">Show</button>
```

Setting `type="button"` in buttons makes them ignored when enter is clicked.