### PR TITLE
fix: budget list search #P23-375

### DIFF
--- a/apps/web/app/(navigation)/SideNavigationBar.tsx
+++ b/apps/web/app/(navigation)/SideNavigationBar.tsx
@@ -138,7 +138,7 @@ export default function SideNav() {
       },
       resetSearch: () => {
         setSearchValue("");
-      }
+      },
     },
     navigationList: (
       <NavList

--- a/apps/web/app/(navigation)/SideNavigationBar.tsx
+++ b/apps/web/app/(navigation)/SideNavigationBar.tsx
@@ -237,7 +237,7 @@ export default function SideNav() {
         isNavListItemClicked={isNavListItemClicked}
         resetIsNavListItemClicked={resetIsNavListItemClicked}
         refetchBudgetsFunction={refetch}
-        resetSearch={setSearchValue}
+        resetSearch={() => setSearchValue("")}
       />
       <>
         {isCreateNewBudgetModalVisible && (

--- a/apps/web/app/(navigation)/SideNavigationBar.tsx
+++ b/apps/web/app/(navigation)/SideNavigationBar.tsx
@@ -136,6 +136,9 @@ export default function SideNav() {
       onChange: (value: string) => {
         setSearchValue(value);
       },
+      resetSearch: () => {
+        setSearchValue("");
+      }
     },
     navigationList: (
       <NavList
@@ -237,6 +240,7 @@ export default function SideNav() {
         isNavListItemClicked={isNavListItemClicked}
         resetIsNavListItemClicked={resetIsNavListItemClicked}
         refetchBudgetsFunction={refetch}
+        resetSearch={setSearchValue}
       />
       <>
         {isCreateNewBudgetModalVisible && (

--- a/apps/web/app/(navigation)/SideNavigationBar.tsx
+++ b/apps/web/app/(navigation)/SideNavigationBar.tsx
@@ -136,9 +136,6 @@ export default function SideNav() {
       onChange: (value: string) => {
         setSearchValue(value);
       },
-      resetSearch: () => {
-        setSearchValue("");
-      },
     },
     navigationList: (
       <NavList

--- a/packages/ui/SideNavigationBar/SubMenu/index.tsx
+++ b/packages/ui/SideNavigationBar/SubMenu/index.tsx
@@ -91,10 +91,6 @@ const IconWrapperStyled = styled.div`
 export const SubMenu = ({ subMenuDataObject: subMenuData }: SubMenuProps) => {
   const { title, sort, searchInput, navigationList, button } = subMenuData;
 
-  useEffect(() => {
-    return () => searchInput?.onChange?.("");
-  }, []);
-
   const onInputChange = (value: string) => {
     searchInput?.onChange?.(value);
   };

--- a/packages/ui/SideNavigationBar/SubMenu/index.tsx
+++ b/packages/ui/SideNavigationBar/SubMenu/index.tsx
@@ -91,6 +91,10 @@ const IconWrapperStyled = styled.div`
 export const SubMenu = ({ subMenuDataObject: subMenuData }: SubMenuProps) => {
   const { title, sort, searchInput, navigationList, button } = subMenuData;
 
+  useEffect(() => {
+    return () => searchInput?.onChange?.("");
+  }, []);
+
   const onInputChange = (value: string) => {
     searchInput?.onChange?.(value);
   };

--- a/packages/ui/SideNavigationBar/index.tsx
+++ b/packages/ui/SideNavigationBar/index.tsx
@@ -71,7 +71,6 @@ export const SideNavigationBar = ({
   const showSubMenu = (id: string) => {
     if (subMenuData && subMenuId === id && !isNavListItemClicked) {
       return hideSubMenu();
-      
     }
     setSubMenuId(id);
     resetIsNavListItemClicked();

--- a/packages/ui/SideNavigationBar/index.tsx
+++ b/packages/ui/SideNavigationBar/index.tsx
@@ -18,6 +18,7 @@ type SideNavigationBarProps = {
   isNavListItemClicked: boolean;
   resetIsNavListItemClicked: () => void;
   refetchBudgetsFunction: () => void;
+  resetSearch: Function;
 };
 
 type SubMenuBoolean = {
@@ -49,6 +50,7 @@ export const SideNavigationBar = ({
   isNavListItemClicked,
   resetIsNavListItemClicked,
   refetchBudgetsFunction,
+  resetSearch,
 }: SideNavigationBarProps) => {
   const [subMenuId, setSubMenuId] = useState("");
   const [isSubMenuShown, setIsSubMenuShown] = useState(false);
@@ -63,15 +65,18 @@ export const SideNavigationBar = ({
     setSubMenuId("");
     setIsSubMenuShown(false);
     refetchBudgetsFunction();
+    resetSearch();
   };
 
   const showSubMenu = (id: string) => {
     if (subMenuData && subMenuId === id && !isNavListItemClicked) {
       return hideSubMenu();
+      
     }
     setSubMenuId(id);
     resetIsNavListItemClicked();
     setIsSubMenuShown(true);
+    resetSearch();
   };
 
   const handleLinkClick = (id: string) => {


### PR DESCRIPTION
# Hello! 👋
Task [Fix Budget List Search](https://tracker.intive.com/jira/browse/PATRO23-375)

## What fixes:
1. Now when you type something in search bar and change tab (e.g. Reports) and open Budgets again, search bar will be empty and budget list will show all budgets.
2. When you go to specyfic budget after search and then open again budget list, search bar again will be empty and budget list will show all budgets.

Thanks to @Noshi96 for a hint how to fix it in a comment on Slack :)