### PR TITLE
fix: credentials error #P23-376

### DIFF
--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -68,6 +68,7 @@ export default function SignInPage() {
         signIn("credentials", {
           email: values.email,
           password: values.password,
+          redirect: false,
         }).then((res) => {
           if (res!.ok) {
             router.push("/");

--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -34,7 +34,7 @@ const FieldsWrapper = styled.div`
 const ErrorWrapper = styled.div`
   position: absolute;
   width: 100%;
-  top: 1rem;
+  top: -1rem;
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;
@@ -46,7 +46,7 @@ const InputWrapper = styled.div`
 
 const ErrorSuportingMsg = styled.div`
   position: absolute;
-  top: 60px;
+  top: 0px;
   left: 10px;
   color: #b3261e;
   font-size: small;

--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -46,7 +46,7 @@ const InputWrapper = styled.div`
 
 const ErrorSuportingMsg = styled.div`
   position: absolute;
-  top: 0px;
+  top: 60px;
   left: 10px;
   color: #b3261e;
   font-size: small;


### PR DESCRIPTION
Tiny fix for the situation when you type in the wrong credentials and the error does not display, instead, the page reloads.

I don't know why this got removed in some previous PR:
`redirect: false,`
