### PR TITLE
fix: no redirect on sign in #P23-387

### DIFF
--- a/apps/web/app/(regflow)/sign-in/page.tsx
+++ b/apps/web/app/(regflow)/sign-in/page.tsx
@@ -64,13 +64,14 @@ export default function SignInPage() {
 
   return (
     <Form
-      onSubmit={async (values) => {
+      onSubmit={(values) => {
         signIn("credentials", {
           email: values.email,
           password: values.password,
           redirect: false,
         }).then((res) => {
-          if (res!.ok) {
+          if (res?.ok) {
+            router.refresh();
             router.push("/");
           } else {
             setErrMsg(t(form.errorMessage));
@@ -139,7 +140,7 @@ export default function SignInPage() {
                 )}
               </Field>
             </FieldsWrapper>
-            <Button onClick={submit} type="submit" fullWidth>
+            <Button type="submit" fullWidth>
               {t(form.submitButton)}
             </Button>
             <FormFooter

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -13,7 +13,7 @@ export default withAuth(
 
     //append new routes if needed in future
     const authRoutes = ["/sign-up", "/sign-in"];
-    const sensitiveRoutes = ["/budgets", "/reports", "/"];
+    const sensitiveRoutes = ["/budgets", "/reports", "/settings", "/"];
     const adminRoutes = ["/users"];
 
     //auth safeguards
@@ -61,5 +61,6 @@ export const config = {
     "/users",
     "/budgets/:path*",
     "/reports/:path*",
+    "/settings/:path*",
   ],
 };

--- a/packages/ui/Button/index.tsx
+++ b/packages/ui/Button/index.tsx
@@ -28,7 +28,7 @@ type ButtonProps = {
   variant?: "primary" | "secondary" | "danger" | "simple";
   fullWidth?: boolean;
   disabled?: boolean;
-  onClick: Function;
+  onClick?: Function;
   small?: boolean;
 } & React.HTMLProps<HTMLButtonElement>;
 


### PR DESCRIPTION
## Fix for no redirect on sign-in
task: https://tracker.intive.com/jira/browse/PATRO23-387

### What changed 🔨 
- user should be now redirected correctly after pressing the "sign in" button

### Why it stopped working 🤔
It looks like on production build after login, Next Router needs to be refreshed to access routes to which user previously had no access (`/`) (route `/` was recently changed to be protected).

To reproduce this error locally, you have to run production build locally:
- go to `apps/web` folder in terminal and 
- run commands `npm run build` then `npm run start`

### Other fixes 🔧 
- if user would logout while being on one of the "settings" subpages, then they would end up not on login page but on "settings" page, but without the side nav bar
- login form was sending request twice, since the button is of `type="submit"` and had also `onClick={submit}`