### PR TITLE
refactor: fix adding lastBudgetRef, refactor removeDuplicates function #P23-396

### DIFF
--- a/apps/web/components/SideNavigationBar/index.tsx
+++ b/apps/web/components/SideNavigationBar/index.tsx
@@ -98,7 +98,7 @@ export default function SideNav() {
   };
 
   const mapToBudgetsComponents = (budgets: BudgetType[]) => {
-    return budgets.map(({ icon, name, id, isFavourite }) => ({
+    return budgets.map(({ icon, name, id, isFavourite }, index, list) => ({
       ComponentToRender: (
         <>
           <IconStyled icon={validate(icon) ? icon : "help"} iconSize={24} />
@@ -112,22 +112,36 @@ export default function SideNav() {
       ),
       href: `/budgets/${id.value}`,
       id: id.value,
-      ref: lastBudgetRef,
+      ref: index === list.length - 1 ? lastBudgetRef : null,
     }));
   };
 
-  const removeDuplicates = (fetchedBudgets: BudgetType[]) => {
-    return fetchedBudgets.filter(
-      (budget, idx) =>
-        fetchedBudgets
-          .map((object) => object.id.value)
-          .indexOf(budget.id.value) === idx
-    );
+  interface UniqueObject {
+    [key: string]: boolean;
+  }
+  const createKey = (obj: BudgetType) => {
+    return obj.id.value;
+  };
+
+  const removeDuplicates = (fetchedBudgets: BudgetType[], fn: Function) => {
+    const unique: UniqueObject = {};
+    const distinct: BudgetType[] = [];
+
+    fetchedBudgets.forEach((fetchedBudget: BudgetType) => {
+      const key = fn(fetchedBudget);
+
+      if (!unique[key]) {
+        distinct.push(fetchedBudget);
+        unique[key] = true;
+      }
+    });
+
+    return distinct;
   };
 
   const flatData = data?.pages?.flatMap(({ items }: ItemType) => items) ?? [];
 
-  const uniqueValues = removeDuplicates(flatData);
+  const uniqueValues = removeDuplicates(flatData, createKey);
 
   const successData = mapToBudgetsComponents(uniqueValues);
 

--- a/packages/ui/NavList/index.tsx
+++ b/packages/ui/NavList/index.tsx
@@ -14,7 +14,7 @@ export type NavItemContents = {
   ComponentToRender?: ReactElement;
   href: string;
   id: string | number;
-  ref?: (budget: HTMLLIElement) => void;
+  ref?: null | ((budget: HTMLLIElement) => void);
 };
 
 //types of NavList props - NavList will receive props `contents` that will be an Array full of objects of NavItemContents type


### PR DESCRIPTION
<h2> Quick improvement for removing duplicates from budget's list 🏃 </h2>

As @wlechowicz suggested: 
- Logic of removeDuplicates function has been changed 
- Bug with adding lastBudgetRef has been fixed  

> This is a bug that's been sitting here for a while, might as well fix it now. This adds last budget ref to every single budget on the list, instead of the last one. 