### PR TITLE
fix: svg "auto" error fix#P23-399

### DIFF
--- a/apps/web/app/(navigation)/budgets/[id]/BudgetDetails/TrendChart.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/BudgetDetails/TrendChart.tsx
@@ -121,7 +121,7 @@ export const TrendChart = ({ statistics, currency }: TrendChartProps) => {
     if (statistics.items.length < 2) {
       return (
         <StyledChartPlaceholder
-          height=""
+          height="100%"
           viewBox="0 0 240 80"
           xmlns="http://www.w3.org/2000/svg">
           <path

--- a/apps/web/app/(navigation)/budgets/[id]/BudgetDetails/TrendChart.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/BudgetDetails/TrendChart.tsx
@@ -121,7 +121,7 @@ export const TrendChart = ({ statistics, currency }: TrendChartProps) => {
     if (statistics.items.length < 2) {
       return (
         <StyledChartPlaceholder
-          height="auto"
+          height=""
           viewBox="0 0 240 80"
           xmlns="http://www.w3.org/2000/svg">
           <path


### PR DESCRIPTION
Small fix that removes: Error: <svg> attribute height: Expected length, "auto" for placeholder trendchart