### PR TITLE
refactor: sorting transactions by column - BE integration #P23-403

### DIFF
--- a/apps/web/app/(navigation)/budgets/[id]/BudgetContent/CreateNewBudget.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/BudgetContent/CreateNewBudget.tsx
@@ -266,7 +266,6 @@ export const CreateNewBudget = ({ onClose }: NewBudget) => {
                     )}
                   </Field>
                 </InputWrapperHalfStyledCurrency>
-
                 <Field
                   name="description"
                   initialValue={""}
@@ -280,8 +279,15 @@ export const CreateNewBudget = ({ onClose }: NewBudget) => {
                           name="description"
                           placeholder={""}
                           label={t(dict.inputNames.description)}
+                          value={value}
+                          hasError={errors.length > 0}
+                          onChange={(e) => {
+                            setValue(e.currentTarget.value);
+                          }}
                         />
-                        <TextareaErrorStyled>{errors[0]}</TextareaErrorStyled>
+                        <TextareaErrorStyled>
+                          {errors.at(0)}
+                        </TextareaErrorStyled>
                       </TextAreaWrapperStyled>
                     );
                   }}

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
@@ -114,6 +114,14 @@ export const TransactionsTable = ({
     [locale]
   );
 
+  const columnMap = {
+    category: "CategoryType",
+    description: "Name",
+    amount: "Value",
+    date: "BudgetTransactionDate",
+    creator: "Email",
+  };
+
   const isSortedByColumn = (column: string | undefined) => {
     return sortDescriptors.find((element) => element.columnName === column);
   };
@@ -183,12 +191,19 @@ export const TransactionsTable = ({
           },
           headCellContent: {
             content: ({ column }) => {
-              const isSortedByThis = isSortedByColumn(column.key);
+              const isSortedByThis = isSortedByColumn(
+                columnMap[column.key as keyof typeof columnMap]
+              );
               return (
                 <>
                   <span>{column.title}</span>
                   {column.key !== "editColumn" && (
-                    <button onClick={() => setSorting(column.key)}>
+                    <button
+                      onClick={() =>
+                        setSorting(
+                          columnMap[column.key as keyof typeof columnMap]
+                        )
+                      }>
                       <Icon
                         icon="sort"
                         iconSize={20}

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
@@ -29,7 +29,13 @@ type Item = {
   name: string;
   value: number;
   budgetTransactionDate: string;
-  categoryType: "HomeSpendings" | "Subscriptions" | "Car" | "Grocery";
+  categoryType:
+    | "HomeSpendings"
+    | "Subscriptions"
+    | "Car"
+    | "Grocery"
+    | "Salary"
+    | "Refund";
 };
 
 type ID = {
@@ -48,7 +54,7 @@ const TransactionTableController = ({ budget }: { budget: BudgetFixed }) => {
   >(null);
   const [searchTransactionByName, setSearchTransactionByName] = useState("");
   const [sortDescriptors, setSortDescriptors] = useState([
-    { columnName: "Name", sortAscending: true },
+    { columnName: "BudgetTransactionDate", sortAscending: false },
   ]);
   const debouncedSearch = useDebounce(searchTransactionByName, 500);
   const { t, dict } = useTranslate("BudgetsPage");

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
@@ -48,7 +48,7 @@ const TransactionTableController = ({ budget }: { budget: BudgetFixed }) => {
   >(null);
   const [searchTransactionByName, setSearchTransactionByName] = useState("");
   const [sortDescriptors, setSortDescriptors] = useState([
-    { columnName: "description", sortAscending: true },
+    { columnName: "Name", sortAscending: true },
   ]);
   const debouncedSearch = useDebounce(searchTransactionByName, 500);
   const { t, dict } = useTranslate("BudgetsPage");


### PR DESCRIPTION
I added a mapping of our columns from the transaction table to the column names BE requires in SortDescriptor. This allowed to combine @mpiwonski previous work with the current version of the BE endpoint.