### PR TITLE
refactor: creator avatar in transaction table #P23-405

### DIFF
--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
@@ -7,7 +7,7 @@ import { languageAtom } from "store";
 import { Table } from "ka-table";
 import { DataType } from "ka-table/enums";
 import { Column } from "ka-table/models";
-import { Icon, Avatar, DropdownMenu, CategoryIcon } from "ui";
+import { Icon, Avatar, DropdownMenu, CategoryIcon, PersonalCard } from "ui";
 
 import { useTranslate } from "lib/hooks";
 import useLocaleDateString from "lib/hooks/useLocaleDateString";
@@ -174,13 +174,24 @@ export const TransactionsTable = ({
                   );
                 case "creator":
                   return props.value ? (
-                    <Avatar
-                      className="avatar"
-                      src={
-                        isAvatarValid(props.value.avatar)
-                          ? props.value.avatar
-                          : "/default.svg"
+                    <PersonalCard
+                      key={props.value.id}
+                      triggerComponent={
+                        <Avatar
+                          className="avatar"
+                          src={
+                            isAvatarValid(props.value.avatar)
+                              ? props.value.avatar
+                              : "/avatars/default.svg"
+                          }
+                          username={`${props.value.firstName} ${props.value.lastName}`}
+                          outlined
+                        />
                       }
+                      side="left"
+                      name={`${props.value.firstName} ${props.value.lastName}`}
+                      email={props.value.userEmail}
+                      image={props.value.avatar}
                     />
                   ) : (
                     <></>

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/TransactionsTable.tsx
@@ -19,6 +19,7 @@ import {
 } from "./TransactionsTable.styled";
 
 import TableSuspense from "components/TableSuspense";
+import isAvatarValid from "lib/validations/avatarValidation";
 
 type SortDescriptor = {
   columnName: string;
@@ -172,7 +173,18 @@ export const TransactionsTable = ({
                     />
                   );
                 case "creator":
-                  return <Avatar className="avatar" src={props.value.avatar} />;
+                  return props.value ? (
+                    <Avatar
+                      className="avatar"
+                      src={
+                        isAvatarValid(props.value.avatar)
+                          ? props.value.avatar
+                          : "/default.svg"
+                      }
+                    />
+                  ) : (
+                    <></>
+                  );
                 case "editColumn":
                   return (
                     <DropdownMenu items={dropdownMenuItems} side="right" />

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
@@ -36,6 +36,13 @@ type Item = {
     | "Grocery"
     | "Salary"
     | "Refund";
+  user: {
+    id: string;
+    avatar: string;
+    firstName: string;
+    lastName: string;
+    userEmail: string;
+  };
 };
 
 type ID = {
@@ -89,11 +96,7 @@ const TransactionTableController = ({ budget }: { budget: BudgetFixed }) => {
           : categoryMap.HomeSpendings,
         description: item.name,
         status: "Done",
-        creator: {
-          id: budget.userId,
-          name: session!.user.name,
-          avatar: session!.user.image,
-        },
+        creator: item.user,
       })
     );
   };

--- a/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
+++ b/apps/web/app/(navigation)/budgets/[id]/TransactionTableController/index.tsx
@@ -36,7 +36,7 @@ type Item = {
     | "Grocery"
     | "Salary"
     | "Refund";
-  user: {
+  budgetUser?: {
     id: string;
     avatar: string;
     firstName: string;
@@ -96,7 +96,7 @@ const TransactionTableController = ({ budget }: { budget: BudgetFixed }) => {
           : categoryMap.HomeSpendings,
         description: item.name,
         status: "Done",
-        creator: item.user,
+        creator: item.budgetUser,
       })
     );
   };

--- a/apps/web/lib/types/index.ts
+++ b/apps/web/lib/types/index.ts
@@ -6,14 +6,6 @@ export interface Currency {
   locale: string;
 }
 
-// interface Creator {
-//   id: string;
-//   firstName: string;
-//   lastName: string;
-//   avatar: string;
-//   userEmail: string;
-// }
-
 export interface Transaction {
   id: string;
   date: number;

--- a/apps/web/lib/types/index.ts
+++ b/apps/web/lib/types/index.ts
@@ -6,11 +6,13 @@ export interface Currency {
   locale: string;
 }
 
-interface Creator {
-  id: string;
-  name: string;
-  avatar: string;
-}
+// interface Creator {
+//   id: string;
+//   firstName: string;
+//   lastName: string;
+//   avatar: string;
+//   userEmail: string;
+// }
 
 export interface Transaction {
   id: string;
@@ -19,7 +21,7 @@ export interface Transaction {
   category: CategoryType;
   description: string;
   status: string;
-  creator: Creator;
+  creator?: BudgetUser;
 }
 
 export interface BudgetUser {


### PR DESCRIPTION
The creator's avatar displayed in the transaction table has been changed, now it is the user's avatar returned by BE. If the transaction does not have an assigned user, no avatar is displayed (this applies to old transactions).

There is an error on smutna 🐸  and even for new transactions a user is not added (BE checks why), for 2 other users for whom I checked for new transactions, users are added and they are correctly displayed in the table.

I also added a Personal Card to the avatar in the table