### PR TITLE
feat: export budgets via mail #P23-361

### DIFF
--- a/apps/web/components/SideNavigationBar/index.tsx
+++ b/apps/web/components/SideNavigationBar/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useRef, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
 import { env } from "env.mjs";
 import { useSession } from "next-auth/react";
@@ -169,6 +169,30 @@ export default function SideNav() {
     enabled: !!session,
   });
 
+  const exportBudgetsByMailMutation = useMutation({
+    mutationFn: () => {
+      return superFetch(
+        `${env.NEXT_PUBLIC_API_URL}budgets/budgets/export/mail`,
+        {
+          method: "POST",
+        }
+      );
+    },
+    onSuccess: ({ httpStatus }) => {
+      if (httpStatus === 200) {
+        showToast({
+          variant: "confirm",
+          message: tExport(dictExport.toastMessages.emailSent),
+        });
+      } else {
+        showToast({
+          variant: "error",
+          message: tImport(dictImport.responseErrors.default),
+        });
+      }
+    },
+  });
+
   const budgetsSubMenuData = {
     title: t(SideNav.budgetsItem.title),
     sort: {
@@ -210,6 +234,10 @@ export default function SideNav() {
       },
       label: t(SideNav.budgetsItem.exportButtonLabel),
       csvUri: exportData?.uri,
+    },
+    exportBudgetsByMailButton: {
+      clickHandler: () => exportBudgetsByMailMutation.mutate(),
+      label: tExport(dictExport.sendEmailText),
     },
     importButton: {
       clickHandler: () => {

--- a/packages/ui/ExportDropdown/index.tsx
+++ b/packages/ui/ExportDropdown/index.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import styled from "styled-components";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   DropdownMenuItemStyled,
-  DropdownMenuContentStyled as MenuContentStyled,
+  DropdownMenuContentStyled,
 } from "../ButtonWithDropdown";
 import { Tooltip } from "ui";
 
@@ -20,10 +19,6 @@ export type ExportDropdownItem = {
   id: string;
   node: React.ReactNode;
 };
-
-const DropdownMenuContentStyled = styled(MenuContentStyled)`
-  width: 100%;
-`;
 
 export const ExportDropdown = ({
   items,

--- a/packages/ui/SideNavigationBar/SubMenu/SubMenu.styled.tsx
+++ b/packages/ui/SideNavigationBar/SubMenu/SubMenu.styled.tsx
@@ -96,6 +96,15 @@ export const ImportExportButtonStyled = styled.button`
   ${ImportExportButtonsStyle};
 `;
 
+export const ExportBudgetsByMailStyled = styled(Button)`
+  padding: 0;
+  font-weight: normal;
+  color: ${({ theme }) => theme.button.primary.main};
+  &:hover {
+    text-decoration: none;
+  }
+`;
+
 export const LinkStyled = styled.a`
   display: flex;
   text-decoration: none;

--- a/packages/ui/SideNavigationBar/SubMenu/index.tsx
+++ b/packages/ui/SideNavigationBar/SubMenu/index.tsx
@@ -15,6 +15,7 @@ import {
   ImportExportButtonStyled,
   NewBudgetButtonStyled,
   Title,
+  ExportBudgetsByMailStyled,
 } from "./SubMenu.styled";
 import { Tooltip } from "../../Tooltip";
 
@@ -41,6 +42,7 @@ export type SubMenuDataProps = {
   button?: SubMenuButtonType;
   exportButton?: SubMenuButtonType;
   importButton?: SubMenuButtonType;
+  exportBudgetsByMailButton?: SubMenuButtonType;
 };
 
 type SubMenuProps = {
@@ -56,6 +58,7 @@ export const SubMenu = ({ subMenuDataObject: subMenuData }: SubMenuProps) => {
     button,
     exportButton,
     importButton,
+    exportBudgetsByMailButton,
   } = subMenuData;
 
   const onInputChange = (value: string) => {
@@ -92,10 +95,24 @@ export const SubMenu = ({ subMenuDataObject: subMenuData }: SubMenuProps) => {
     </LinkStyled>
   );
 
+  const emailButton = (
+    <ExportBudgetsByMailStyled
+      onClick={exportBudgetsByMailButton?.clickHandler}
+      title="email"
+      variant="simple">
+      <Icon icon="file_upload" size={12} />
+      <span>{exportBudgetsByMailButton?.label}</span>
+    </ExportBudgetsByMailStyled>
+  );
+
   const exportBudgetsDropdownItems = [
     {
       id: "export-budgets-download",
       node: downloadLink,
+    },
+    {
+      id: "export-budgets-email",
+      node: emailButton,
     },
   ];
 


### PR DESCRIPTION
Ticket: https://tracker.intive.com/jira/browse/PATRO23-361

By selecting send by email from the export dropdown option, we can export our budgets. After a successful operation, the budgets as a CSV file will be sent to our email address, and we will see a success toast.