### PR TITLE
feat: refresh token #P23-369

### DIFF
--- a/apps/web/lib/hooks/useSuperfetch.ts
+++ b/apps/web/lib/hooks/useSuperfetch.ts
@@ -1,8 +1,9 @@
-import { signOut, useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "ui";
 import { dictionaryType } from "lib/dictionary";
-import { useRouter } from "next/navigation";
 import { useTranslate } from "./useTranslate";
+import { useEffect } from "react";
 
 export interface SuperOptions extends Omit<RequestInit, "headers" | "body"> {
   body?: object;
@@ -10,8 +11,8 @@ export interface SuperOptions extends Omit<RequestInit, "headers" | "body"> {
 
 export default function useSuperfetch() {
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
   const showToast = useToast();
-  const router = useRouter();
   const { t, dict } = useTranslate("Errors");
 
   const superfetch = (
@@ -47,12 +48,10 @@ export default function useSuperfetch() {
           message: t(dict.noErrorCode),
         });
       } else if (res.status === 401) {
-        showToast({
-          variant: "error",
-          message: t(dict.status401),
-        });
-        signOut();
-        router.push("/");
+        if (session) {
+          console.log("session");
+          queryClient.clear();
+        }
       } else if (res.status === 403) {
         console.log(t(dict.status403));
       } else if (res.status === 404) {

--- a/apps/web/lib/types/next-auth.d.ts
+++ b/apps/web/lib/types/next-auth.d.ts
@@ -9,6 +9,18 @@ declare module "next-auth" {
       name: string;
       role: UserRole;
       email: string;
+      error?: string;
     };
+  }
+}
+
+declare module "@auth/core/jwt" {
+  interface JWT {
+    accessToken: string;
+    expiresIn: number;
+    refreshExpiresIn: number;
+    refreshToken: string;
+    sub: string;
+    error?: "RefreshAccessTokenError";
   }
 }

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,4 @@
-import NextAuth, { NextAuthOptions, User } from "next-auth";
+import NextAuth, { NextAuthOptions, TokenSet, User } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import jwt from "jsonwebtoken";
 import { env } from "env.mjs";
@@ -24,21 +24,79 @@ interface DefaultUser extends User {
   refreshToken: string;
   role: UserRole;
   id: string;
+  expiresIn: number;
+  image: string;
+  error?: string;
 }
 
 export const authOptions: NextAuthOptions = {
   callbacks: {
-    jwt({ token, account, user }) {
+    async jwt({ token, account, user }) {
       if (account) {
-        token.accessToken = (user as DefaultUser).accessToken;
-        token.role = (user as DefaultUser).role;
+        const { accessToken, role, expiresIn, refreshToken, id, image } =
+          user as DefaultUser;
+        console.log(
+          "expiresAt ",
+          Math.floor(Date.now() + Number(expiresIn) * 1000)
+        );
+        return {
+          accessToken,
+          expiresAt: Math.floor(Date.now() + Number(expiresIn) * 1000),
+          refreshToken,
+          role,
+          id,
+          expiresIn,
+          image,
+        };
+      } else if (Date.now() < Number(token.expiresAt)) {
+        // If the access token has not expired yet, return it
+        return token;
+      } else {
+        // If the access token has expired, try to refresh it
+        try {
+          const res = await fetch(
+            `${env.NEXT_PUBLIC_API_URL}user/refresh-token`,
+            {
+              headers: {
+                accept: "*/*",
+                Authorization: `Bearer ${token.accessToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                refreshToken: token.refreshToken,
+              }),
+              method: "POST",
+            }
+          );
+
+          if (!res.ok) throw res;
+
+          const { accessToken, refreshToken, expiresIn }: TokenSet =
+            await res.json();
+
+          console.log(
+            "expiresAt",
+            Math.floor(Date.now() + Number(expiresIn) * 1000)
+          );
+          return {
+            ...token, // Keep the previous token properties, like role
+            accessToken,
+            refreshToken,
+            expiresAt: Math.floor(Date.now() + Number(expiresIn) * 1000),
+          };
+        } catch (error) {
+          console.error("Error refreshing access token", error);
+          // The error property will be used client-side to handle the refresh token error
+          return { ...token, error: "RefreshAccessTokenError" as const };
+        }
       }
-      return token;
     },
     session({ session, token }) {
       session.user.accessToken = token.accessToken as string;
       session.user.role = token.role;
-      session.user.id = token.sub as string;
+      session.user.id = token.id as string;
+      session.user.image = token.image as string;
+      session.user.error = token.error as string;
       return session;
     },
   },
@@ -58,7 +116,7 @@ export const authOptions: NextAuthOptions = {
         });
 
         if (res.ok) {
-          const { accessToken, refreshToken } = await res.json();
+          const { accessToken, refreshToken, expiresIn } = await res.json();
 
           const { sub, name, avatar, realm_access, email } = jwt.decode(
             accessToken
@@ -72,6 +130,7 @@ export const authOptions: NextAuthOptions = {
             name,
             image: avatar,
             email,
+            expiresIn,
           };
         } else return null;
       },


### PR DESCRIPTION
The refresh token is not working properly. The only way it works now is to leave the focus from the web tab after the token expires, and then tanstackquery will do a refetchOnWindowFocus and refetch all queries with the correct new token. When we are still on the web page after the token expires, we get an error. Somehow tanstackquery, when it receives the first response with a 401, continues fetching with the old accessToken, even though it should have already been replaced.